### PR TITLE
Remove previous build_artifacts directory

### DIFF
--- a/app/client/build_runner.py
+++ b/app/client/build_runner.py
@@ -1,7 +1,8 @@
 import http.client
 import os
-import time
+import shutil
 import sys
+import time
 
 from app.master.build import BuildStatus, BuildResult
 import app.util.fs
@@ -135,6 +136,10 @@ class BuildRunner(object):
         download_artifacts_url = self._master_api.url('build', self._build_id, 'result')
         download_filepath = 'build_results/artifacts.tar.gz'
         download_dir, _ = os.path.split(download_filepath)
+
+        # remove any previous build artifacts
+        if os.path.exists(download_dir):
+            shutil.rmtree(download_dir)
 
         while time.time() <= timeout_time:
             response = self._network.get(download_artifacts_url)


### PR DESCRIPTION
Right now, `clusterrunner build` will download results to the directory
named "build_results". Files from new builds will replace files from
previous builds, but if any artifacts from old builds are not replaced,
the file will still remain.

This change removes the build_artifacts directory before downloading new
build artifacts.

This behavior (ensuring correct build results file structure) should be
tested with a functional test.
