### PR TITLE
Make clusterrunner deploy error messages more user-friendly

### DIFF
--- a/app/deployment/remote_master_service.py
+++ b/app/deployment/remote_master_service.py
@@ -19,9 +19,10 @@ class RemoteMasterService(RemoteService):
         :param timeout_sec: number of seconds to wait for the master to respond before timing out
         :type timeout_sec: int
         """
-        self._execute_ssh_command('nohup {} master --port {} &'.format(self._executable_path, str(port)))
-        master_service_url = '{}:{}'.format(self._host, str(port))
+        self._execute_ssh_command('nohup {} master --port {} &'.format(self._executable_path, str(port)), async=True)
+        master_service_url = '{}:{}'.format(self.host, str(port))
         master_service = ServiceRunner(master_service_url)
 
         if not master_service.is_up(master_service_url, timeout=timeout_sec):
-            raise RuntimeError('Master service running on {} failed to start.'.format(master_service_url))
+            self._logger.error('Master service running on {} failed to start.'.format(master_service_url))
+            raise SystemExit(1)

--- a/app/deployment/remote_service.py
+++ b/app/deployment/remote_service.py
@@ -1,3 +1,4 @@
+from app.util.log import get_logger
 from app.util.shell.factory import ShellClientFactory
 
 
@@ -15,7 +16,8 @@ class RemoteService(object):
         :param executable_path: the path to the clusterrunner executable on the remote host
         :type executable_path: str
         """
-        self._host = host
+        self._logger = get_logger(__name__)
+        self.host = host
         self._username = username
         self._executable_path = executable_path
         self._shell_client = ShellClientFactory.create(host, username)
@@ -27,17 +29,17 @@ class RemoteService(object):
         """
         self._execute_ssh_command('{} stop'.format(self._executable_path))
 
-    def _execute_ssh_command(self, command):
+    def _execute_ssh_command(self, command, async=False):
         """
         Helper method for executing ssh commands.
 
         :param command: command to execute remotely
         :type command: str
+        :param async: async/non-blocking call?
+        :type async: bool
         """
         self._shell_client.connect()
-
-        # Run these commands asynchronously because they are services...
-        self._shell_client.exec_command(command, async=True)
+        self._shell_client.exec_command(command, async)
         self._shell_client.close()
 
     def host(self):
@@ -45,4 +47,4 @@ class RemoteService(object):
         :return:
         :rtype: str
         """
-        return self._host
+        return self.host

--- a/app/deployment/remote_slave_service.py
+++ b/app/deployment/remote_slave_service.py
@@ -23,4 +23,4 @@ class RemoteSlaveService(RemoteService):
         slave_args = '--master-url {}:{}'.format(master_host, str(master_port))
         slave_args += ' --port {}'.format(str(slave_port))
         slave_args += ' --num-executors {}'.format(str(num_executors))
-        self._execute_ssh_command('nohup {} slave {} &'.format(self._executable_path, slave_args))
+        self._execute_ssh_command('nohup {} slave {} &'.format(self._executable_path, slave_args), async=True)

--- a/test/unit/deployment/test_remote_master_service.py
+++ b/test/unit/deployment/test_remote_master_service.py
@@ -1,0 +1,17 @@
+from app.deployment.remote_master_service import RemoteMasterService
+from test.framework.base_unit_test_case import BaseUnitTestCase
+
+
+class TestRemoteMasterService(BaseUnitTestCase):
+    def test_start_and_block_until_up_raises_exception_if_master_service_not_up(self):
+        self.patch('app.deployment.remote_service.ShellClientFactory')
+        self.patch('app.deployment.remote_master_service.ServiceRunner').return_value.is_up.return_value = False
+        remote_master_service = RemoteMasterService('some_host', 'some_username', 'some_path')
+        with self.assertRaisesRegex(SystemExit, '1'):
+            remote_master_service.start_and_block_until_up(43000, 5)
+
+    def test_start_and_block_until_up_doesnt_raise_exception_if_master_service_is_up(self):
+        self.patch('app.deployment.remote_service.ShellClientFactory')
+        self.patch('app.deployment.remote_master_service.ServiceRunner').return_value.is_up.return_value = True
+        remote_master_service = RemoteMasterService('some_host', 'some_username', 'some_path')
+        remote_master_service.start_and_block_until_up(43000, 5)

--- a/test/unit/subcommands/test_deploy_subcommand.py
+++ b/test/unit/subcommands/test_deploy_subcommand.py
@@ -1,0 +1,93 @@
+import socket
+
+from app.subcommands.deploy_subcommand import DeploySubcommand
+from test.framework.base_unit_test_case import BaseUnitTestCase
+
+
+class TestDeploySubcommand(BaseUnitTestCase):
+    def setUp(self):
+        super().setUp()
+
+    def test_binaries_tar_raises_exception_if_running_from_source(self):
+        deploy_subcommand = DeploySubcommand()
+        with self.assertRaisesRegex(SystemExit, '1'):
+            deploy_subcommand._binaries_tar('python main.py deploy', '~/.clusterrunner/dist')
+
+    def test_binaries_doesnt_raise_exception_if_running_from_bin(self):
+        self.patch('os.path.isfile').return_value = True
+        self.patch('app.subcommands.deploy_subcommand.compress_directory')
+        deploy_subcommand = DeploySubcommand()
+        deploy_subcommand._binaries_tar('clusterrunner', '~/.clusterrunner/dist')
+
+    def test_deploy_binaries_and_conf_does_nothing_if_socket_gaierror_raised(self):
+        mock_DeployTarget = self.patch('app.subcommands.deploy_subcommand.DeployTarget')
+        mock_DeployTarget.side_effect = socket.gaierror()
+        mock_DeployTarget_instance = mock_DeployTarget.return_value
+        deploy_subcommand = DeploySubcommand()
+        deploy_subcommand._deploy_binaries_and_conf(
+            ['host_1'], 'invalid_host', 'username', 'exec', '/path/to/exec', '/path/to/conf')
+        self.assertFalse(mock_DeployTarget_instance.deploy_binary.called)
+        self.assertFalse(mock_DeployTarget_instance.deploy_conf.called)
+
+    def test_deploy_binaries_and_conf_deploys_both_conf_and_binary_for_remote_host(self):
+        mock_DeployTarget = self.patch('app.subcommands.deploy_subcommand.DeployTarget')
+        mock_DeployTarget_instance = mock_DeployTarget.return_value
+        deploy_subcommand = DeploySubcommand()
+        deploy_subcommand._deploy_binaries_and_conf(
+            ['remote_host'], 'taejun', 'username', 'exec', '/path/to/exec', '/path/to/conf')
+        self.assertTrue(mock_DeployTarget_instance.deploy_binary.called)
+        self.assertTrue(mock_DeployTarget_instance.deploy_conf.called)
+
+    def test_deploy_binaries_and_conf_doesnt_deploy_conf_if_localhost_with_same_in_use_conf(self):
+        self.patch('os.path.expanduser').return_value = '/home'
+        mock_DeployTarget = self.patch('app.subcommands.deploy_subcommand.DeployTarget')
+        mock_DeployTarget_instance = mock_DeployTarget.return_value
+        deploy_subcommand = DeploySubcommand()
+        deploy_subcommand._deploy_binaries_and_conf(
+            ['localhost'], 'taejun', 'username', 'exec', '/path/to/exec', '/home/.clusterrunner/clusterrunner.conf')
+        self.assertFalse(mock_DeployTarget_instance.deploy_conf.called)
+
+    def test_deploy_binaries_and_conf_deploys_conf_if_localhost_with_diff_in_use_conf(self):
+        self.patch('os.path.expanduser').return_value = '/home'
+        mock_DeployTarget = self.patch('app.subcommands.deploy_subcommand.DeployTarget')
+        mock_DeployTarget_instance = mock_DeployTarget.return_value
+        deploy_subcommand = DeploySubcommand()
+        deploy_subcommand._deploy_binaries_and_conf(
+            ['localhost'],
+            'taejun',
+            'username',
+            'exec',
+            '/path/to/exec',
+            '/home/.clusterrunner/clusterrunner_prime.conf'
+        )
+        self.assertTrue(mock_DeployTarget_instance.deploy_conf.called)
+
+    def test_deploy_binaries_and_conf_deploys_binaries_if_localhost_and_different_executable_path_in_use(self):
+        self.patch('os.path.expanduser').return_value = '/home'
+        mock_DeployTarget = self.patch('app.subcommands.deploy_subcommand.DeployTarget')
+        mock_DeployTarget_instance = mock_DeployTarget.return_value
+        deploy_subcommand = DeploySubcommand()
+        deploy_subcommand._deploy_binaries_and_conf(
+            ['localhost'],
+            'taejun',
+            'username',
+            '/home/.clusterrunner/dist/clusterrunner_rime',
+            '/home/.clusterrunner/clusterrunner.tgz',
+            '/clusterrunner.conf'
+        )
+        self.assertTrue(mock_DeployTarget_instance.deploy_binary.called)
+
+    def test_deploy_binaries_and_conf_doesnt_deploy_binaries_if_localhost_and_same_executable_path_in_use(self):
+        self.patch('os.path.expanduser').return_value = '/home'
+        mock_DeployTarget = self.patch('app.subcommands.deploy_subcommand.DeployTarget')
+        mock_DeployTarget_instance = mock_DeployTarget.return_value
+        deploy_subcommand = DeploySubcommand()
+        deploy_subcommand._deploy_binaries_and_conf(
+            ['localhost'],
+            'taejun',
+            'username',
+            '/home/.clusterrunner/dist/clusterrunner',
+            '/home/.clusterrunner/clusterrunner.tgz',
+            '/clusterrunner.conf'
+        )
+        self.assertFalse(mock_DeployTarget_instance.deploy_binary.called)


### PR DESCRIPTION
and also have it exit with the proper exit code. Was previously exiting
with a 0 exit code even upon failure.

Additionally, fix the async/blocking issue where the 'stop' command was
being asynchronously executed when it should have been a blocking call.
