### PR TITLE
Fix issue where atomizer command fails silently

### DIFF
--- a/app/master/atomizer.py
+++ b/app/master/atomizer.py
@@ -1,0 +1,48 @@
+from app.util import log
+
+
+class Atomizer(object):
+    """
+    An Atomizer takes care of translating the commands as parsed from the "atomizers" section of the project config
+    into a list of atoms. The actual computed atoms are just environment variable export shell commands that are then
+    prepended to whatever commands were specified in the "commands" section of the project config.
+    """
+    def __init__(self, atomizer_dicts):
+        """
+        :param atomizer_dicts: A list of dicts mapping atomizer env var names to atomizer commands
+        :type atomizer_dicts: list[dict[str, str]]
+        """
+        self._logger = log.get_logger(__name__)
+        self._atomizer_dicts = atomizer_dicts
+
+    def atomize_in_project(self, project_type):
+        """
+        Translate the atomizer dicts that this instance was initialized with into a list of actual atom commands. This
+        executes atomizer commands inside the given project in order to generate the atoms.
+
+        :param project_type: The ProjectType instance in which to execute the atomizer commands
+        :type project_type: ProjectType
+        :return: The list of environment variable "export" atom commands
+        :rtype: list[str]
+        """
+        atoms_list = []
+        for atomizer_dict in self._atomizer_dicts:
+            for atomizer_var_name, atomizer_command in atomizer_dict.items():
+                atomizer_output, exit_code = project_type.execute_command_in_project(atomizer_command)
+                if exit_code != 0:
+                    self._logger.error('Atomizer command "{}" for variable "{}" failed with exit code: {} and output:'
+                                       '\n{}', atomizer_command, atomizer_var_name, exit_code, atomizer_output)
+                    raise AtomizerError('Atomizer command failed!')
+
+                # Convert atomizer command output into environment variable export commands.
+                new_atoms = ['export {}="{}";'.format(atomizer_var_name, atom_value)
+                             for atom_value in atomizer_output.strip().splitlines()]
+                atoms_list.extend(new_atoms)
+
+        return atoms_list
+
+
+class AtomizerError(Exception):
+    """
+    Represents an error during atomization.
+    """

--- a/app/master/cluster_runner_config.py
+++ b/app/master/cluster_runner_config.py
@@ -1,176 +1,151 @@
+import sys
 import yaml
 
+from app.master.atomizer import Atomizer
 from app.master.job_config import JobConfig
-import app.util.fs
 from app.util import log
 
 
+# clusterrunner.yaml config section names
+SETUP_BUILD = 'setup_build'
+TEARDOWN_BUILD = 'teardown_build'
+COMMANDS = 'commands'
+ATOMIZERS = 'atomizers'
+MAX_EXECUTORS = 'max_executors'
+
+
 class ClusterRunnerConfig(object):
-    def __init__(self, raw_yaml_contents=None):
-        self._job_configs = {}
+    DEFAULT_MAX_EXECUTORS = sys.maxsize
+
+    def __init__(self, raw_yaml_contents):
+        """
+        :param raw_yaml_contents: Raw string contents of project clusterrunner.yaml file
+        :type raw_yaml_contents: string
+        """
+        self._job_configs = None
         self._logger = log.get_logger(__name__)
         self._raw_yaml_contents = raw_yaml_contents
-
-    def read(self, raw_yaml_contents=None):
-        """
-        :param raw_yaml_contents: raw string of boxci yaml file
-        :type raw_yaml_contents: string | None
-        """
-        raw_yaml_contents = raw_yaml_contents or self._raw_yaml_contents
-        config = yaml.safe_load(raw_yaml_contents)
-
-        self._validate(config)
-        self.set_config(config)
-
-    def write(self, filename):
-        """
-        :param filename: file to write yaml to
-        :type filename: string
-        """
-        serialized = yaml.dump(self._job_configs)
-        app.util.fs.write_file(serialized, filename)
-
-    def _validate(self, config):
-        if not isinstance(config, dict):
-            raise ConfigParseError('The yaml config file could not be parsed to a dictionary')
-        required_fields = ['commands', 'atomizers']
-        allowed_fields = ['setup_build', 'teardown_build', 'commands', 'atomizers', 'max_executors']
-        for job_name, job_values in config.items():
-            if job_values is None:
-                raise ConfigValidationError('No definition found for job {}'.format(job_name))
-            for field in required_fields:
-                if not isinstance(job_values.get(field), list):
-                    raise ConfigValidationError('For job "{}", expected the project yaml file to contain a list value '
-                                                'for the "{}" key. Found "{}" instead'.format(field, job_name,
-                                                                                              job_values.get(field)))
-            for value_name in job_values.keys():
-                if value_name not in allowed_fields:
-                    raise ConfigValidationError(
-                        'An invalid key "{}" was found in the config for job {}'.format(value_name, job_name))
-
-    def set_config(self, config):
-        """
-        :param config: Config values for one or more jobs, with job names as the keys
-        :type config: dict [str, dict]
-        """
-        self._job_configs = {
-            job_name: self._construct_job_config(job_name, job_values) for job_name, job_values in config.items()
-        }
-
-        if len(self._job_configs) == 0:
-            raise ConfigParseError('No jobs found in the config.')
-
-    def job_names(self):
-        return list(self._job_configs.keys())
 
     def get_job_config(self, job_name=None):
         """
         Get a list of job configs contained in this cluster runner config, optionally filtered by job names.
+        :param job_name:
         :type job_name: str | None
-        :rtype: JobConfig | None
+        :return: The specified job config
+        :rtype: JobConfig
         """
-        if len(self._job_configs) == 0:
-            self.read()
+        if self._job_configs is None:
+            self._parse_raw_config()
 
         if job_name is not None:
             if job_name not in self._job_configs:
-                raise JobNotFoundError('The job {} was not found. Valid jobs are {}'.format(job_name, self.job_names()))
+                raise JobNotFoundError('The job "{}" was not found in the loaded config. '
+                                       'Valid jobs are: {}'.format(job_name, self.get_job_names()))
             return self._job_configs[job_name]
 
         if len(self._job_configs) == 1:
-            return next(iter(self._job_configs.values()))
+            return list(self._job_configs.values())[0]
 
         raise JobNotSpecifiedError('Multiple jobs are defined in this project but you did not specify one. '
-                                   'Specify one of the following job names: {}'.format(self.job_names()))
+                                   'Specify one of the following job names: {}'.format(self.get_job_names()))
 
-    def _construct_job_config(self, name, job_values):
+    def get_job_names(self):
         """
-        Produces a JobConfig object given a dictionary of values parsed from a yaml config file
-        :type name: str
+        Get the names of all the jobs defined in the associated config file.
+        :return: A list of all job names in the config file
+        :rtype: list[str]
+        """
+        if self._job_configs is None:
+            self._parse_raw_config()
+
+        return list(self._job_configs.keys())
+
+    def _parse_raw_config(self):
+        config = yaml.safe_load(self._raw_yaml_contents)
+        self._validate(config)
+        self._set_config(config)
+
+    def _validate(self, config):
+        """
+        Validate the parsed yaml structure. This method raises on validation errors.
+        :param config: The parsed yaml data
+        :type config: dict
+        """
+        if not isinstance(config, dict):
+            raise ConfigParseError('The yaml config file could not be parsed to a dictionary')
+
+        required_fields = {COMMANDS, ATOMIZERS}
+        allowed_fields_expected_types = {
+            SETUP_BUILD: [(list, str)],  # (list, str) means this field should be a list of strings
+            TEARDOWN_BUILD: [(list, str)],
+            COMMANDS: [(list, str)],
+            ATOMIZERS: [(list, dict)],  # (list, dict) means this field should be a list of dicts
+            MAX_EXECUTORS: [int],
+        }
+
+        for job_name, job_config_sections in config.items():
+            if not isinstance(job_config_sections, dict):
+                raise ConfigValidationError('Invalid definition in project yaml file for job "{}".'.format(job_name))
+
+            missing_required_fields = required_fields - job_config_sections.keys()
+            if missing_required_fields:
+                raise ConfigValidationError('Definition for job "{}" in project yaml is missing required config '
+                                            'sections: {}.'.format(job_name, missing_required_fields))
+
+            for config_section_name, config_section_value in job_config_sections.items():
+                if config_section_name not in allowed_fields_expected_types:
+                    raise ConfigValidationError('Definition for job "{}" in project yaml contains an invalid config '
+                                                'section "{}".'.format(job_name, config_section_name))
+
+                expected_section_types = allowed_fields_expected_types[config_section_name]
+                actual_section_type = type(config_section_value)
+                if actual_section_type is list:
+                    # also check the type of the list items (assuming all list items have the same type as the first)
+                    actual_section_type = (list, type(config_section_value[0]))
+
+                if actual_section_type not in expected_section_types:
+                    raise ConfigValidationError(
+                        'Definition for job "{}" in project yaml contains an invalid value for config section "{}". '
+                        'Parser expected one of {} but found {}.'
+                        .format(job_name, config_section_name, expected_section_types, actual_section_type))
+
+    def _set_config(self, config):
+        """
+        Translate the parsed and validated config data into JobConfig objects, and save the results to an attribute
+        on this instance.
+        :param config: Config values for one or more jobs, with job names as the keys
+        :type config: dict [str, dict]
+        """
+        self._job_configs = {job_name: self._construct_job_config(job_name, job_values)
+                             for job_name, job_values in config.items()}
+
+        if len(self._job_configs) == 0:
+            raise ConfigParseError('No jobs found in the config.')
+
+    def _construct_job_config(self, job_name, job_values):
+        """
+        Produce a JobConfig object given a dictionary of values parsed from a yaml config file.
+        :param job_name: The name of the job
+        :type job_name: str
+        :param job_values: The dict of config sections for this job as parsed from the yaml file
         :type job_values: dict
-        :return:
+        :return: A JobConfig object wrapping the normalized data for the specified job
+        :rtype: JobConfig
         """
-        # Each value should be transformed from a list to a single command string
-        setup_build = self._shell_command_list_to_single_command(job_values.get('setup_build'))
-        teardown_build = self._shell_command_list_to_single_command(job_values.get('teardown_build'))
-        command = self._shell_command_list_to_single_command(job_values.get('commands'))
+        # Each value should be transformed from a list of commands to a single command string.
+        setup_build = self._shell_command_list_to_single_command(job_values.get(SETUP_BUILD))
+        teardown_build = self._shell_command_list_to_single_command(job_values.get(TEARDOWN_BUILD))
+        command = self._shell_command_list_to_single_command(job_values[COMMANDS])
 
-        # Parse atomizers
-        atomizers = job_values.get('atomizers')
-        atomizer_commands = [self._atomizer_command(atomizer) for atomizer in atomizers]
-        atomizer = self._shell_command_list_to_single_command(atomizer_commands)
+        atomizer = Atomizer(job_values[ATOMIZERS])
+        max_executors = job_values.get(MAX_EXECUTORS, self.DEFAULT_MAX_EXECUTORS)
 
-        # Parse max_executors
-        try:
-            max_executors = int(job_values.get('max_executors'))
-        except (ValueError, TypeError):
-            self._logger.warning('The config value for max_processes is not parsable as an int.')
-            max_executors = float('inf')
-
-        return JobConfig(name, setup_build, teardown_build, command, atomizer, max_executors)
-
-    def _atomizer_command(self, atomizer_element):
-        """
-        We support 3 types of atomizer commands, freeform shell strings, environment vars from shell strings,
-        and environment vars from a path and a regex.
-        :type atomizer_element: dict [str, str] | dict [str, dict] | str
-        :rtype: str
-        """
-        if isinstance(atomizer_element, str):
-            # Freeform atomizer shell command
-            return atomizer_element
-        if isinstance(atomizer_element, dict):
-            # Environment var atomizer
-            return self._atomizer_environment_variable(atomizer_element)
-        raise ConfigParseError('Atomizer found but element is not a string or dictionary')
-
-    def _atomizer_environment_variable(self, atomizer_element):
-        """
-        There are two types of environment var atomizers: shell command and regex.
-        :type atomizer_element: dict [str, str] | dict [str, dict]
-        :rtype: str
-        """
-        var_name = self._atomizer_environment_var_name(atomizer_element)
-        first_element = next(iter(atomizer_element.values()))
-        if isinstance(first_element, dict):
-            # Regex environment var atomizer
-            command = self._atomizer_regex(first_element)
-        elif isinstance(first_element, str):
-            # Shell command environment var atomizer
-            command = first_element
-        else:
-            raise ConfigParseError('Atomizer for environment variable found but value is not a string or dictionary')
-
-        return "{} | xargs -I {{}} echo 'export {}=\"'{{}}'\"'".format(command, var_name)
-
-    def _atomizer_regex(self, regex_params):
-        """
-        A regex atomizer takes two params, the path and the regex.  We generate a command that returns all files
-        in the path that match the regex.
-        :type regex_params: dict [str, str]
-        :rtype: str
-        """
-        if 'path' not in regex_params or 'regex' not in regex_params:
-            raise ConfigParseError('Regex atomizer detected but it does not contain "path" and "regex" keys')
-        # @todo: properly escape quotes in regex_params['regex'] and spaces in 'path'
-        return 'find {} -regex "{}"'.format(regex_params['path'], regex_params['regex'])
-
-    def _atomizer_environment_var_name(self, atomizer_element):
-        """
-        We use the dictionary key as the environment variable name
-        :type atomizer_element: dict [str, str] | dict [str, dict]
-        :return:
-        """
-        if len(atomizer_element) != 1:
-            raise ConfigParseError(
-                'Environment var atomizer should contain 1 key, actually contains {}'.format(len(atomizer_element)))
-
-        return next(iter(atomizer_element.keys()))
+        return JobConfig(job_name, setup_build, teardown_build, command, atomizer, max_executors)
 
     def _shell_command_list_to_single_command(self, commands):
         """
         Combines a list of commands into a single bash string
-        :param commands: a list of commands, possibly ending with semicolons, but not guaranteed
+        :param commands: a list of commands, optionally ending with semicolons
         :type commands: list[str]
         :return: returns the concatenated shell command on success, or None if there was an error
         :rtype: string|None
@@ -201,25 +176,21 @@ class ConfigParseError(Exception):
     """
     The cluster runner config could not be parsed
     """
-    pass
 
 
 class JobNotFoundError(Exception):
     """
     The requested job could not be found in the config
     """
-    pass
 
 
 class JobNotSpecifiedError(Exception):
     """
     Multiple jobs were found in the config but none were specified
     """
-    pass
 
 
 class ConfigValidationError(Exception):
     """
     The cluster runner config was invalid
     """
-    pass

--- a/app/master/job_config.py
+++ b/app/master/job_config.py
@@ -1,3 +1,5 @@
+
+
 class JobConfig(object):
     def __init__(self, name, setup_build, teardown_build, command, atomizer, max_executors):
         """
@@ -5,10 +7,9 @@ class JobConfig(object):
         :type setup_build: str | None
         :type teardown_build: str | None
         :type command: str
-        :type atomizer: str
+        :type atomizer: Atomizer
         :type max_executors: int | None
         """
-
         self.name = name
         self.setup_build = setup_build
         self.teardown_build = teardown_build

--- a/app/project_type/project_type.py
+++ b/app/project_type/project_type.py
@@ -31,7 +31,6 @@ class ProjectType(object):
         :rtype: JobConfig
         """
         config = ClusterRunnerConfig(self._get_config_contents())
-
         return config.get_job_config(self._job_name)
 
     def _get_config_contents(self):

--- a/test/unit/master/test_atomizer.py
+++ b/test/unit/master/test_atomizer.py
@@ -1,0 +1,36 @@
+from unittest.mock import MagicMock
+from app.master.atomizer import Atomizer, AtomizerError
+
+from app.project_type.project_type import ProjectType
+from test.framework.base_unit_test_case import BaseUnitTestCase
+
+
+_FAKE_ATOMIZER_COMMAND = 'find . -name test_*.py'
+_FAKE_ATOMIZER_COMMAND_OUTPUT = './test_a.py\n./test_b.py\n./test_c.py\n'
+_SUCCESSFUL_EXIT_CODE = 0
+_FAILING_EXIT_CODE = 1
+
+
+class TestAtomizer(BaseUnitTestCase):
+    def test_atomizer_returns_expected_atom_list(self):
+        mock_project = MagicMock(spec_set=ProjectType)
+        mock_project.execute_command_in_project.return_value = (_FAKE_ATOMIZER_COMMAND_OUTPUT, _SUCCESSFUL_EXIT_CODE)
+
+        atomizer = Atomizer([{'TEST_FILE': _FAKE_ATOMIZER_COMMAND}])
+        actual_atoms = atomizer.atomize_in_project(mock_project)
+
+        expected_atoms = ['export TEST_FILE="./test_a.py";',
+                          'export TEST_FILE="./test_b.py";',
+                          'export TEST_FILE="./test_c.py";']
+        self.assertListEqual(expected_atoms, actual_atoms, 'List of actual atoms should match list of expected atoms.')
+        mock_project.execute_command_in_project.assert_called_once_with(_FAKE_ATOMIZER_COMMAND)
+
+    def test_atomizer_raises_exception_when_atomize_command_fails(self):
+        mock_project = MagicMock(spec_set=ProjectType)
+        mock_project.execute_command_in_project.return_value = ('ERROR ERROR ERROR', _FAILING_EXIT_CODE)
+
+        atomizer = Atomizer([{'TEST_FILE': _FAKE_ATOMIZER_COMMAND}])
+        with self.assertRaises(AtomizerError):
+            atomizer.atomize_in_project(mock_project)
+
+        mock_project.execute_command_in_project.assert_called_once_with(_FAKE_ATOMIZER_COMMAND)

--- a/test/unit/master/test_cluster_runner_config.py
+++ b/test/unit/master/test_cluster_runner_config.py
@@ -1,5 +1,7 @@
 from box.test.genty import genty, genty_dataset
+import sys
 
+from app.master.atomizer import Atomizer
 from app.master.cluster_runner_config import ClusterRunnerConfig, ConfigParseError, ConfigValidationError
 from test.framework.base_unit_test_case import BaseUnitTestCase
 
@@ -15,7 +17,7 @@ class TestClusterRunnerConfig(BaseUnitTestCase):
             - sleep 1
         commands:
             - echo "Now I'm doing $THE_THING!";  # semicolons in this section
-            - echo "Semicolons are fun." > /tmp/all_my_hard_work.txt;
+            - echo "Semicolons are fun." > /tmp/my_hard_work.txt;
         atomizers:
             - THE_THING: printf 'something with a number %d\\n' {1..50}
     """
@@ -39,16 +41,6 @@ class TestClusterRunnerConfig(BaseUnitTestCase):
             - echo "go"
         atomizers:
             - "export VARNAME='asdf'"
-    """
-
-    _REGEX_ATOMIZER = """
-    PHPUnit:
-        commands:
-            - echo "go"
-        atomizers:
-            - VAR_NAME:
-                path: /path/to/project
-                regex: "[s|S]imple regex"
     """
 
     _MINIMAL_CONFIG = """
@@ -86,22 +78,24 @@ class TestClusterRunnerConfig(BaseUnitTestCase):
     """
 
     @genty_dataset(
-        ('name', 'Best Job Ever'),
-        ('max_executors', 21),
-        ('setup_build', 'echo "This is setup! Woo!" && sleep 1 '),
-        ('command', 'echo "Now I\'m doing $THE_THING!" && echo "Semicolons are fun." > /tmp/all_my_hard_work.txt '),
-        ('atomizer',
-         'printf \'something with a number %d\\n\' {1..50} | xargs -I {} echo \'export THE_THING="\'{}\'"\' '),
+        name=('name', 'Best Job Ever'),
+        max_executors=('max_executors', 21),
+        setup_build=('setup_build', 'echo "This is setup! Woo!" && sleep 1 '),
+        command=('command', 'echo "Now I\'m doing $THE_THING!" && echo "Semicolons are fun." > /tmp/my_hard_work.txt '),
+        atomizer=('atomizer', [{'THE_THING': 'printf \'something with a number %d\\n\' {1..50}'}])
     )
     def test_all_conf_properties_are_correctly_parsed(self, conf_method_name, expected_value):
         config = ClusterRunnerConfig(self._COMPLETE_VALID_CONFIG)
         job_config = config.get_job_config()
         actual_value = getattr(job_config, conf_method_name)
+        if isinstance(actual_value, Atomizer):
+            actual_value = actual_value._atomizer_dicts  # special case comparison for atomizer
+
         self.assertEqual(actual_value, expected_value,
                          'The output of {}() should match the expected value.'.format(conf_method_name))
 
     @genty_dataset(
-        ('max_executors', float('inf')),
+        ('max_executors', sys.maxsize),
         ('setup_build', None),
     )
     def test_undefined_conf_properties_return_default_values(self, conf_method_name, expected_value):
@@ -127,12 +121,12 @@ class TestClusterRunnerConfig(BaseUnitTestCase):
         self.assertTrue(is_expected_valid, 'Config is not valid, but parsed without error')
 
     @genty_dataset(
-        _FREEFORM_ATOMIZER,
-        _REGEX_ATOMIZER
+        freeform_atomizer=(_FREEFORM_ATOMIZER,),
     )
-    def test_atomizer_types(self, config_contents):
+    def test_incorrect_atomizer_type_raises_exception(self, config_contents):
         config = ClusterRunnerConfig(config_contents)
-        config.get_job_config()
+        with self.assertRaises(ConfigValidationError):
+            config.get_job_config()
 
     def test_get_specific_job_config(self):
         config = ClusterRunnerConfig(self._MULTI_JOB_CONFIG)


### PR DESCRIPTION
Previousy we had logic to check the exit code of the atomizer command,
but since we were piping the defined command through xargs the "real"
command could fail silently. The effect of this would be that we'd
construct invalid atoms (containing whatever error message output by
the failing command), which would be sent to slaves and executed as
shell commands.

Since we would then execute error message strings as shell code, the
effects of this could be unpredictable and potentially dangerous!

The main changes in this commit are:
- A general refactoring of our ClusterRunnerConfig class which greatly
  simplifies the logic involved in parsing the atomizer section. (This
  removes a few undocumented atomizer formats that we aren't using.)
- A new Atomizer class -- this is what now holds the logic for
  converting the data structure parsed from yaml into the executable
  atom commands.
