### PR TITLE
Add switch for simplified log format

### DIFF
--- a/app/subcommands/build_subcommand.py
+++ b/app/subcommands/build_subcommand.py
@@ -28,7 +28,7 @@ class BuildSubcommand(Subcommand):
         :type request_params: dict
         """
         log_level = log_level or Configuration['log_level']
-        log.configure_logging(log_level=log_level)
+        log.configure_logging(log_level=log_level, simplified_console_logs=True)
         request_params['type'] = build_type or request_params.get('type') or 'directory'
 
         if remote_file:

--- a/app/subcommands/deploy_subcommand.py
+++ b/app/subcommands/deploy_subcommand.py
@@ -53,7 +53,11 @@ class DeploySubcommand(Subcommand):
         :param num_executors: the number of executors that will be run per slave
         :type num_executors: int | None
         """
-        log.configure_logging(log_level=log_level or Configuration['log_level'], log_file=Configuration['log_file'])
+        log.configure_logging(
+            log_level=log_level or Configuration['log_level'],
+            log_file=Configuration['log_file'],
+            simplified_console_logs=True,
+        )
         in_use_conf_path = Configuration['config_file']
         hostname = Configuration['hostname']
         current_executable = sys.executable

--- a/app/subcommands/stop_subcommand.py
+++ b/app/subcommands/stop_subcommand.py
@@ -24,7 +24,7 @@ class StopSubcommand(Subcommand):
         :type log_level: str | None
         """
         log_level = log_level or Configuration['log_level']
-        log.configure_logging(log_level=log_level)
+        log.configure_logging(log_level=log_level, simplified_console_logs=True)
         self._kill_pid_in_file_if_exists(Configuration['slave_pid_file'])
         self._kill_pid_in_file_if_exists(Configuration['master_pid_file'])
 


### PR DESCRIPTION
We made a change previously to simplify the log format and coloring
for console/stdout output. (I believe this was so that subcommands
like 'build' and 'deploy' produced more user friendly output.) This
is a bit too simple though since it is still useful to have the full
log format when running master and slave services.

We can have it both ways! This adds a flag to the configure_logging
call that will switch between the standard and simplfied log format.
