### PR TITLE
Add CORS support for API requests

### DIFF
--- a/app/util/conf/base_config_loader.py
+++ b/app/util/conf/base_config_loader.py
@@ -75,6 +75,9 @@ class BaseConfigLoader(object):
         conf.set('master_port', '43000')
         conf.set('slaves', ['localhost'])
 
+        # CORS support - a regex to match against allowed API request origins, or None to disable CORS
+        conf.set('cors_allowed_origins_regex', None)
+
     def configure_postload(self, conf):
         """
         After the clusterrunner.conf file has been loaded, generate the paths which descend from the base_directory
@@ -118,6 +121,7 @@ class BaseConfigLoader(object):
             'master_port',
             'log_filename',
             'eventlog_filename',
+            'cors_allowed_origins_regex',
         ]
         try:
             config_parsed = ConfigFile(config_filename).read_config_from_disk()

--- a/app/web_framework/cluster_master_application.py
+++ b/app/web_framework/cluster_master_application.py
@@ -242,8 +242,6 @@ class _SlaveDisconnectHandler(_ClusterMasterBaseHandler):
 
 class _EventlogHandler(_ClusterMasterBaseHandler):
     def get(self):
-        self.set_header('Access-Control-Allow-Origin', '*')  # todo: put value of this in user conf (moar security!)
-
         # all arguments are optional, so default to None
         since_timestamp = self.get_query_argument('since_timestamp', None)
         since_id = self.get_query_argument('since_id', None)

--- a/conf/default_clusterrunner.conf
+++ b/conf/default_clusterrunner.conf
@@ -7,15 +7,21 @@
 [general]
 ## The root directory for files used during the build process.
 # base_directory = ~/.clusterrunner
+
 ## Symlinks to each build's project files are created here, to keep paths consistent across machines.
 # build_symlink_directory = /tmp/clusterrunner_build_symlinks
 
 ## The level to log at.  Other options are DEBUG, INFO, NOTICE, WARNING, ERROR, and CRITIAL.
 # log_level = 'WARNING'
+
 ## A list of slaves, used for starting slaves with the "clusterrunner deploy" command
 # slaves = hostname01.example.com, hostname02.example.com, hostname03.example.com
+
 ## The hostname to refer to the local machine with
 # hostname = localhost
+
+## CORS support - a regex to match against allowed API request origins, or None to disable CORS
+# cors_allowed_origins_regex = None
 
 [master]
 ## The port the master service will run on
@@ -24,10 +30,12 @@
 [slave]
 ## The port the slave service will run on
 # port = 43001
+
 ## The maximum number of parallel executions to run on this slave
 # num_executors = 1
 
 ## The master's hostname this slave will connect to
 # master_hostname = localhost
+
 ## The master's port this slave will connect to
 # master_port = 43000

--- a/test/unit/web_framework/test_cluster_base_handler.py
+++ b/test/unit/web_framework/test_cluster_base_handler.py
@@ -1,0 +1,50 @@
+from box.test.genty import genty, genty_dataset
+import tornado.httpserver
+from unittest.mock import ANY, call, MagicMock
+
+from app.util.conf.configuration import Configuration
+from app.web_framework.cluster_application import ClusterApplication
+from app.web_framework.cluster_base_handler import ClusterBaseHandler
+from test.framework.base_unit_test_case import BaseUnitTestCase
+
+
+@genty
+class TestClusterBaseHandler(BaseUnitTestCase):
+
+    @genty_dataset(
+        when_request_contains_no_origin_header=(None, '.*'),
+        when_cors_conf_value_has_not_been_set=('http://alice.in-wonder.land:8080', None),
+        when_request_origin_is_not_allowed=('http://alice.in-wonder.land:8080', 'http://bill\.in-wonder\.land:\d*'),
+    )
+    def test_set_default_headers_should_not_set_origin_header(self, request_origin, cors_conf_value):
+        mock_application = MagicMock(spec_set=ClusterApplication())
+        mock_request = MagicMock(spec=tornado.httpserver.HTTPRequest, headers={})
+        if cors_conf_value:
+            Configuration['cors_allowed_origins_regex'] = cors_conf_value
+        if request_origin:
+            mock_request.headers['Origin'] = request_origin
+
+        handler = ClusterBaseHandler(mock_application, mock_request)
+        handler.set_header = MagicMock()
+        handler.set_default_headers()
+
+        any_set_origin_header_call = call('Access-Control-Allow-Origin', ANY)
+        self.assertNotIn(any_set_origin_header_call, handler.set_header.call_args_list,
+                         'set_default_headers() should not set the Access-Control-Allow-Origin header.')
+
+    @genty_dataset(
+        when_request_origin_is_allowed=('http://alice.in-wonder.land:8080', 'http://[^.]*\.in-wonder\.land'),
+    )
+    def test_set_default_headers_should_set_origin_header(self, request_origin, cors_conf_value):
+        mock_application = MagicMock(spec_set=ClusterApplication())
+        mock_request = MagicMock(spec=tornado.httpserver.HTTPRequest, headers={})
+        Configuration['cors_allowed_origins_regex'] = cors_conf_value
+        mock_request.headers['Origin'] = request_origin
+
+        handler = ClusterBaseHandler(mock_application, mock_request)
+        handler.set_header = MagicMock()
+        handler.set_default_headers()
+
+        expected_set_origin_header_call = call('Access-Control-Allow-Origin', request_origin)
+        self.assertIn(expected_set_origin_header_call, handler.set_header.call_args_list,
+                      'set_default_headers() should not set the Access-Control-Allow-Origin header.')


### PR DESCRIPTION
This change will allow users of ClusterRunner to build dashboards
against the ClusterRunner API while keeping the API secure against
unlimited cross-origin access.
