### PR TITLE
Stub filesystem side effects in unit tests

### DIFF
--- a/app/master/cluster_master.py
+++ b/app/master/cluster_master.py
@@ -10,7 +10,7 @@ from app.master.slave import Slave
 from app.util import analytics
 from app.util.conf.configuration import Configuration
 from app.util.exceptions import ItemNotFoundError, ItemNotReadyError
-from app.util.fs import create_dir
+from app.util import fs
 from app.util.log import get_logger
 from app.util.ordered_set_queue import OrderedSetQueue
 from app.util.safe_thread import SafeThread
@@ -53,7 +53,7 @@ class ClusterMaster(object):
         if os.path.exists(self._master_results_path):
             shutil.rmtree(self._master_results_path)
 
-        create_dir(self._master_results_path)
+        fs.create_dir(self._master_results_path)
 
     def _get_status(self):
         """

--- a/app/project_type/git.py
+++ b/app/project_type/git.py
@@ -2,9 +2,9 @@ import os
 import pexpect
 from urllib.parse import urlparse
 
+from app.util import fs
 from app.project_type.project_type import ProjectType
 from app.util.conf.configuration import Configuration
-from app.util.fs import create_dir
 
 
 class Git(ProjectType):
@@ -62,9 +62,9 @@ class Git(ProjectType):
         )
 
         # We explicitly set the repo directory to 700 so we don't inadvertently expose the repo to access by other users
-        create_dir(self._repo_directory, 0o700)
-        create_dir(self._timing_file_directory, 0o700)
-        create_dir(os.path.dirname(build_project_directory))
+        fs.create_dir(self._repo_directory, 0o700)
+        fs.create_dir(self._timing_file_directory, 0o700)
+        fs.create_dir(os.path.dirname(build_project_directory))
 
         # Create a symlink from the generated build project directory to the actual project directory.
         # This is done in order to switch between the master's and the slave's copies of the repo while not

--- a/app/subcommands/deploy_subcommand.py
+++ b/app/subcommands/deploy_subcommand.py
@@ -14,11 +14,10 @@ from app.deployment.remote_master_service import RemoteMasterService
 from app.deployment.remote_slave_service import RemoteSlaveService
 from app.subcommands.subcommand import Subcommand
 from app.util.poll import wait_for
-from app.util import log
+from app.util import fs, log
 from app.util.conf.configuration import Configuration
 from app.util.conf.master_config_loader import MasterConfigLoader
 from app.util.conf.slave_config_loader import SlaveConfigLoader
-from app.util.fs import compress_directory
 from app.util.network import Network
 from app.util.url_builder import UrlBuilder
 
@@ -128,7 +127,7 @@ class DeploySubcommand(Subcommand):
             self._logger.info('Compressed tar file {} already exists, skipping compression.'.format(tar_file_path))
             return tar_file_path
 
-        compress_directory(clusterrunner_bin_dir, tar_file_path)
+        fs.compress_directory(clusterrunner_bin_dir, tar_file_path)
         return tar_file_path
 
     def _deploy_binaries_and_conf(self, hosts, local_hostname, username, current_executable, binaries_tar_path,

--- a/app/subcommands/service_subcommand.py
+++ b/app/subcommands/service_subcommand.py
@@ -4,7 +4,7 @@ import sys
 import tornado.ioloop
 
 from app.subcommands.subcommand import Subcommand
-from app.util.fs import write_file
+from app.util import fs
 from app.util.unhandled_exception_handler import UnhandledExceptionHandler
 
 
@@ -30,7 +30,7 @@ class ServiceSubcommand(Subcommand):
         return ioloop
 
     def _write_pid_file(self, filename):
-        write_file(str(os.getpid()), filename)
+        fs.write_file(str(os.getpid()), filename)
 
         def remove_pid_file():
             try:

--- a/app/util/analytics.py
+++ b/app/util/analytics.py
@@ -6,9 +6,9 @@ import os
 import sys
 import time
 
+from app.util import fs
 from app.util.conf.configuration import Configuration
 from app.util.counter import Counter
-from app.util.fs import create_dir
 
 
 BUILD_REQUEST_QUEUED = 'BUILD_REQUEST_QUEUED'
@@ -43,7 +43,7 @@ def initialize(eventlog_file=None):
     if eventlog_file.upper() == 'STDOUT':
         event_handler = StreamHandler(sys.stdout)
     else:
-        create_dir(os.path.dirname(eventlog_file))
+        fs.create_dir(os.path.dirname(eventlog_file))
         previous_log_file_exists = os.path.exists(eventlog_file)
 
         event_handler = RotatingFileHandler(

--- a/app/util/conf/base_config_loader.py
+++ b/app/util/conf/base_config_loader.py
@@ -4,9 +4,8 @@ import platform
 import sys
 import shutil
 
-from app.util import autoversioning
+from app.util import autoversioning, fs
 from app.util.conf.config_file import ConfigFile
-from app.util.fs import create_dir
 
 
 BASE_CONFIG_FILE_SECTION = 'general'
@@ -123,7 +122,7 @@ class BaseConfigLoader(object):
             config_parsed = ConfigFile(config_filename).read_config_from_disk()
         except FileNotFoundError:
             sample_filename = join(config.get('root_directory'), 'conf', 'default_clusterrunner.conf')
-            create_dir(config.get('base_directory'))
+            fs.create_dir(config.get('base_directory'))
             shutil.copy(sample_filename, config_filename)
             chmod(config_filename, ConfigFile.CONFIG_FILE_MODE)
             config_parsed = ConfigFile(config_filename).read_config_from_disk()

--- a/app/util/conf/config_file.py
+++ b/app/util/conf/config_file.py
@@ -2,7 +2,7 @@ from configobj import ConfigObj
 import os
 import stat
 
-from app.util.fs import create_dir
+from app.util import fs
 
 
 class ConfigFile(object):
@@ -43,6 +43,6 @@ class ConfigFile(object):
         Write a data structure of parsed config values to disk in an INI-style format.
         :type config_parsed: ConfigObj
         """
-        create_dir(os.path.dirname(self._filename))
+        fs.create_dir(os.path.dirname(self._filename))
         config_parsed.write()
         os.chmod(self._filename, self.CONFIG_FILE_MODE)

--- a/app/util/fs.py
+++ b/app/util/fs.py
@@ -20,6 +20,7 @@ def create_dir(dir_path, mode=None):
     if mode is not None:
         os.chmod(dir_path, mode)
 
+
 def write_file(file_contents, file_path):
     """
     Write a string or byte string to a file.

--- a/app/util/log.py
+++ b/app/util/log.py
@@ -7,8 +7,8 @@ import os
 import sys
 from termcolor import colored
 
+from app.util import fs
 from app.util.conf.configuration import Configuration
-from app.util.fs import create_dir
 
 
 # This custom format string takes care of setting field widths to make logs more aligned and readable.
@@ -100,7 +100,7 @@ def configure_logging(log_level=None, log_file=None, simplified_console_logs=Fal
 
     # handler for log file
     if log_file:
-        create_dir(os.path.dirname(log_file))
+        fs.create_dir(os.path.dirname(log_file))
         previous_log_file_exists = os.path.exists(log_file)
 
         event_handler = _ColorizingRotatingFileHandler(

--- a/test/unit/master/test_cluster_master.py
+++ b/test/unit/master/test_cluster_master.py
@@ -1,17 +1,17 @@
-import unittest
 from unittest.mock import MagicMock
 
-from test.framework.base_unit_test_case import BaseUnitTestCase
 from app.master.build import Build
 from app.master.build_request import BuildRequest
 from app.master.cluster_master import ClusterMaster
 from app.master.slave import Slave
+from test.framework.base_unit_test_case import BaseUnitTestCase
 
 
 class TestClusterMaster(BaseUnitTestCase):
 
     def setUp(self):
-        self.patch('os.makedirs')
+        self.patch('app.util.fs.create_dir')
+        self.patch('shutil.rmtree')
         super().setUp()
         self.patch('app.master.build.app.util')  # stub out util functions since these often interact with the fs
 

--- a/test/unit/project_type/test_git.py
+++ b/test/unit/project_type/test_git.py
@@ -6,8 +6,8 @@ from test.framework.base_unit_test_case import BaseUnitTestCase
 class TestGit(BaseUnitTestCase):
 
     def setUp(self):
+        self.patch('app.project_type.git.fs.create_dir')
         super().setUp()
-        self.patch('app.project_type.git.create_dir')
 
     def test_timing_file_path_happy_path(self):
         self.patch('os.symlink')

--- a/test/unit/subcommands/test_deploy_subcommand.py
+++ b/test/unit/subcommands/test_deploy_subcommand.py
@@ -6,6 +6,7 @@ from test.framework.base_unit_test_case import BaseUnitTestCase
 
 class TestDeploySubcommand(BaseUnitTestCase):
     def setUp(self):
+        self.patch('app.subcommands.deploy_subcommand.fs.compress_directory')
         super().setUp()
 
     def test_binaries_tar_raises_exception_if_running_from_source(self):
@@ -15,7 +16,6 @@ class TestDeploySubcommand(BaseUnitTestCase):
 
     def test_binaries_doesnt_raise_exception_if_running_from_bin(self):
         self.patch('os.path.isfile').return_value = True
-        self.patch('app.subcommands.deploy_subcommand.compress_directory')
         deploy_subcommand = DeploySubcommand()
         deploy_subcommand._binaries_tar('clusterrunner', '~/.clusterrunner/dist')
 

--- a/test/unit/test_main.py
+++ b/test/unit/test_main.py
@@ -2,12 +2,12 @@ from argparse import ArgumentParser
 from box.test.genty import genty, genty_dataset
 from unittest.mock import Mock, MagicMock
 
-import main
 from app.project_type.project_type import ProjectType
 from app.subcommands.build_subcommand import BuildSubcommand
-from test.framework.base_unit_test_case import BaseUnitTestCase
 from app.util.conf.configuration import Configuration
 from app.util.secret import Secret
+import main
+from test.framework.base_unit_test_case import BaseUnitTestCase
 
 
 @genty
@@ -20,7 +20,7 @@ class TestMain(BaseUnitTestCase):
     _PROJECT_DIRECTORY = 'workspace'
 
     def setUp(self):
-        self.patch('os.makedirs')
+        self.patch('app.util.fs.write_file')
         super().setUp()
         self.mock_tornado = self.patch('app.subcommands.service_subcommand.tornado')
         self.mock_ClusterMaster = self.patch('app.subcommands.master_subcommand.ClusterMaster')
@@ -33,28 +33,21 @@ class TestMain(BaseUnitTestCase):
         self.patch('main.SlaveConfigLoader')
         self.patch('app.util.conf.base_config_loader.platform').node.return_value = self._HOSTNAME
         self.patch('app.subcommands.master_subcommand.analytics.initialize')
-        # self.patch('app.subcommands.service_subcommand.write_file')
 
     def test_master_args_correctly_create_cluster_master(self):
-        # arrange
         mock_cluster_master = self.mock_ClusterMaster.return_value  # get the mock for the ClusterMaster instance
 
-        # act
         main.main(['master'])
 
-        # assert
         self.mock_ClusterMaster.assert_called_once_with()  # assert on constructor params
         self.mock_ClusterMasterApplication.assert_called_once_with(mock_cluster_master)  # assert on constructor params
 
     def test_default_slave_args_correctly_create_cluster_slave(self):
-        # arrange
         self.mock_configuration_values({'num_executors': 1}, default_value='default_value')
         mock_cluster_slave = self.mock_ClusterSlave.return_value
 
-        # act
         main.main(['slave'])
 
-        # assert
         expected_cluster_slave_constructor_args = {
             'num_executors': 1,
             'port': Configuration['port'],


### PR DESCRIPTION
We still had a few unit tests touching the filesystem. This commit
changes the import style of several files, and adds some patches in
BaseUnitTestCase to guard against use of various methods that touch
the filesystem.
