### PR TITLE
Move non-service subcommands onto main thread

### DIFF
--- a/app/subcommands/master_subcommand.py
+++ b/app/subcommands/master_subcommand.py
@@ -8,9 +8,9 @@ from app.web_framework.cluster_master_application import ClusterMasterApplicatio
 
 
 class MasterSubcommand(ServiceSubcommand):
-    thread_name = 'MasterTornadoThread'
+    _THREAD_NAME = 'MasterTornadoThread'
 
-    def run(self, port, log_level, eventlog_file):
+    def async_run(self, port, log_level, eventlog_file):
         """
         Run a ClusterRunner master service.
 

--- a/app/subcommands/service_subcommand.py
+++ b/app/subcommands/service_subcommand.py
@@ -5,6 +5,7 @@ import tornado.ioloop
 
 from app.subcommands.subcommand import Subcommand
 from app.util import fs
+from app.util.safe_thread import SafeThread
 from app.util.unhandled_exception_handler import UnhandledExceptionHandler
 
 
@@ -12,7 +13,19 @@ class ServiceSubcommand(Subcommand):
     """
     Base class for Master and Slave subcommands.
     """
-    def run(self):
+    _THREAD_NAME = None
+
+    def run(self, *args, **kwargs):
+        app_thread = SafeThread(
+            name=self._THREAD_NAME,
+            target=self.async_run,
+            args=args,
+            kwargs=kwargs,
+        )
+        app_thread.start()
+        app_thread.join()
+
+    def async_run(self, *args, **kwargs):
         raise NotImplementedError
 
     def _start_application(self, application, port):

--- a/app/subcommands/slave_subcommand.py
+++ b/app/subcommands/slave_subcommand.py
@@ -8,9 +8,9 @@ from app.web_framework.cluster_slave_application import ClusterSlaveApplication
 
 
 class SlaveSubcommand(ServiceSubcommand):
-    thread_name = 'SlaveTornadoThread'
+    _THREAD_NAME = 'SlaveTornadoThread'
 
-    def run(self, port, master_url, num_executors, log_level, eventlog_file):
+    def async_run(self, port, master_url, num_executors, log_level, eventlog_file):
         """
         Run a ClusterRunner slave service.
 

--- a/app/subcommands/subcommand.py
+++ b/app/subcommands/subcommand.py
@@ -2,7 +2,6 @@ from app.util import log
 
 
 class Subcommand(object):
-    thread_name = 'AppThread'
 
     def __init__(self):
         self._logger = log.get_logger(__name__)

--- a/main.py
+++ b/main.py
@@ -215,16 +215,9 @@ def main(args):
     _initialize_configuration(parsed_args.pop('subcommand'), parsed_args.pop('config_file'))
     subcommand_class = parsed_args.pop('subcommand_class')  # defined in _parse_args() by subparser.set_defaults()
 
-    app_thread = SafeThread(
-        name=subcommand_class.thread_name,
-        target=subcommand_class().run,
-        kwargs=parsed_args,
-    )
-
     unhandled_exception_handler = UnhandledExceptionHandler.singleton()
     with unhandled_exception_handler:
-        app_thread.start()
-        app_thread.join()
+        subcommand_class().run(**parsed_args)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This change moves execution of the non-service subcommands (i.e.,
`build`, `stop`, `deploy`) onto the main thread. There is no good
reason not to execute these on the main thread, and putting them on
the main thread makes them easier to control via signals.

For example, killing a "clusterrunner build" process will now only
require hitting ctrl-C once instead of twice.
