### PR TITLE
Close all file descriptors on server stop

### DIFF
--- a/app/subcommands/master_subcommand.py
+++ b/app/subcommands/master_subcommand.py
@@ -42,4 +42,5 @@ class MasterSubcommand(ServiceSubcommand):
         ioloop.add_callback(log_startup)
 
         ioloop.start()  # this call blocks until the server is stopped
-        self._logger.info('Master service was stopped. Goodbye.')
+        ioloop.close(all_fds=True)  # all_fds=True is necessary here to make sure connections don't hang
+        self._logger.notice('Master server was stopped.')

--- a/app/subcommands/slave_subcommand.py
+++ b/app/subcommands/slave_subcommand.py
@@ -51,4 +51,5 @@ class SlaveSubcommand(ServiceSubcommand):
         ioloop.add_callback(connect_slave_to_master)
 
         ioloop.start()  # this call blocks until the server is stopped
-        self._logger.info('Slave service was stopped. Goodbye.')
+        ioloop.close(all_fds=True)  # all_fds=True is necessary here to make sure connections don't hang
+        self._logger.notice('Slave server was stopped.')

--- a/test/unit/util/test_unhandled_exception_handler.py
+++ b/test/unit/util/test_unhandled_exception_handler.py
@@ -95,19 +95,19 @@ class TestUnhandledExceptionHandler(BaseUnitTestCase):
 
     def test_teardown_callbacks_are_executed_in_reverse_order_of_being_added(self):
         callback = MagicMock()
-        self.exception_handler.add_teardown_callback(callback, 'a')
-        self.exception_handler.add_teardown_callback(callback, 'b')
-        self.exception_handler.add_teardown_callback(callback, 'c')
+        self.exception_handler.add_teardown_callback(callback, 'first')
+        self.exception_handler.add_teardown_callback(callback, 'second')
+        self.exception_handler.add_teardown_callback(callback, 'third')
 
         with suppress(SystemExit):
             with self.exception_handler:
                 raise Exception
 
         expected_calls_in_reverse_order = [
-            call('c'),
-            call('b'),
-            call('a')]
-        self.assertListEqual(callback.mock_calls, expected_calls_in_reverse_order,
+            call('third'),
+            call('second'),
+            call('first')]
+        self.assertListEqual(callback.call_args_list, expected_calls_in_reverse_order,
                              'Teardown callbacks should be executed in reverse order of being added.')
 
     def test_initializing_singleton_on_non_main_thread_raises_exception(self):


### PR DESCRIPTION
This is a fix for an issue in ClusterRunner where even if the Tornado
IOLoop has been stopped, web requests will not be rejected. In fact,
those requests would just hang open indefinitely until the Python
process actually ended.

This had led to some strange effects where if a slave process was
hanging due to a different issue, the master would have connections
open to it. Later when we would manually kill the hanging slave
process, the master connections would finally fail and bring down the
master as well.

The fix is to explicitly close the Tornado IOLoop with an argument to
close all file descriptors. I couldn't find good documentation on why
this fixes the issue, but I verified the fix through manual testing.
