### PR TITLE
Replace the paramiko implementation with direct Popen calls for ssh

### DIFF
--- a/app/deployment/deploy_target.py
+++ b/app/deployment/deploy_target.py
@@ -33,16 +33,12 @@ class DeployTarget(object):
         :type dest_dir: str
         """
         parent_dest_dir = os.path.dirname(dest_dir)
-        self._shell_client.connect()
-
         self._shell_client.exec_command('rm -rf {0}; mkdir -p {0}'.format(dest_dir), error_on_failure=True)
         self._shell_client.copy(source_tar, '{}/clusterrunner.tgz'.format(parent_dest_dir))
         self._shell_client.exec_command(
             command='tar zxvf {}/clusterrunner.tgz -C {}'.format(parent_dest_dir, dest_dir),
             error_on_failure=True
         )
-
-        self._shell_client.close()
 
     def deploy_conf(self, source_path, dest_path):
         """
@@ -57,8 +53,6 @@ class DeployTarget(object):
         if not os.path.exists(source_path):
             raise RuntimeError('Expected configuration file to exist in {}, but does not.'.format(source_path))
 
-        self._shell_client.connect()
         self._shell_client.copy(source_path, dest_path)
         # Must set permissions of conf to '600' for security purposes.
         self._shell_client.exec_command('chmod 600 {}'.format(dest_path), error_on_failure=True)
-        self._shell_client.close()

--- a/app/deployment/remote_master_service.py
+++ b/app/deployment/remote_master_service.py
@@ -19,7 +19,8 @@ class RemoteMasterService(RemoteService):
         :param timeout_sec: number of seconds to wait for the master to respond before timing out
         :type timeout_sec: int
         """
-        self._execute_ssh_command('nohup {} master --port {} &'.format(self._executable_path, str(port)), async=True)
+        self._shell_client.exec_command('nohup {} master --port {} &'.format(self._executable_path, str(port)),
+                                        async=True)
         master_service_url = '{}:{}'.format(self.host, str(port))
         master_service = ServiceRunner(master_service_url)
 

--- a/app/deployment/remote_service.py
+++ b/app/deployment/remote_service.py
@@ -27,17 +27,5 @@ class RemoteService(object):
         Stop all clusterrunner services on this machine. This functionality is in the base class because it
         should be common across all possible subclasses.
         """
-        self._execute_ssh_command('{} stop'.format(self._executable_path))
+        self._shell_client.exec_command('{} stop'.format(self._executable_path), async=False)
 
-    def _execute_ssh_command(self, command, async=False):
-        """
-        Helper method for executing ssh commands.
-
-        :param command: command to execute remotely
-        :type command: str
-        :param async: async/non-blocking call?
-        :type async: bool
-        """
-        self._shell_client.connect()
-        self._shell_client.exec_command(command, async)
-        self._shell_client.close()

--- a/app/deployment/remote_slave_service.py
+++ b/app/deployment/remote_slave_service.py
@@ -23,4 +23,4 @@ class RemoteSlaveService(RemoteService):
         slave_args = '--master-url {}:{}'.format(master_host, str(master_port))
         slave_args += ' --port {}'.format(str(slave_port))
         slave_args += ' --num-executors {}'.format(str(num_executors))
-        self._execute_ssh_command('nohup {} slave {} &'.format(self._executable_path, slave_args), async=True)
+        self._shell_client.exec_command('nohup {} slave {} &'.format(self._executable_path, slave_args), async=True)

--- a/app/util/shell/remote.py
+++ b/app/util/shell/remote.py
@@ -1,4 +1,4 @@
-from paramiko import SSHClient, AutoAddPolicy
+from subprocess import Popen, PIPE
 
 from app.util.log import get_logger
 from app.util.shell.shell_client import ShellClient, Response, EmptyResponse
@@ -8,57 +8,56 @@ class RemoteShellClient(ShellClient):
     def __init__(self, host, user):
         super().__init__(host, user)
         self._logger = get_logger(__name__)
-        self._ssh = None
-        """ :type : SSHClient"""
-
-    def _connect_client(self):
-        if self._ssh is None:
-            self._ssh = SSHClient()
-            self._ssh.set_missing_host_key_policy(AutoAddPolicy())
-        self._ssh.connect(self.host, username=self.user)
-
-    def _close_client(self):
-        self._ssh.close()
 
     def _exec_command_on_client_async(self, command):
         """
-        :param command:
         :type command: str
-        :return:
         :rtype: Response
         """
-        self._logger.debug('SSH async [{}:{}]: {}'.format(self.user, self.host, command))
-        self._ssh.exec_command(command)
-        # todo add a callback to get the real response values
+        escaped_command = self._escaped_ssh_command(command)
+        self._logger.debug('SSH popen async [{}:{}]: {}'.format(self.user, self.host, escaped_command))
+        proc = Popen(escaped_command, shell=True, stdout=PIPE, stderr=PIPE)
         return EmptyResponse()
 
     def _exec_command_on_client_blocking(self, command):
         """
-        :param command:
         :type command: str
-        :return:
         :rtype: Response
         """
-        channel_file_to_bytes = lambda x: ''.join(x.readlines()).encode()
-        self._logger.debug('SSH blocking [{}:{}]: {}'.format(self.user, self.host, command))
-        _, stdout, stderr = self._ssh.exec_command(command)
-        returncode = stdout.channel.recv_exit_status()
-        return Response(
-            raw_output=channel_file_to_bytes(stdout),
-            raw_error=channel_file_to_bytes(stderr),
-            returncode=returncode
-        )
+        escaped_command = self._escaped_ssh_command(command)
+        self._logger.debug('SSH popen blocking [{}:{}]: {}'.format(self.user, self.host, escaped_command))
+        proc = Popen(escaped_command, shell=True, stdout=PIPE, stderr=PIPE)
+        output, error = proc.communicate()
+        return Response(raw_output=output, raw_error=error, returncode=proc.returncode)
 
     def _copy_on_client(self, source, destination):
         """
-        :param source:
         :type source: str
-        :param destination:
         :type destination: str
-        :return:
         :rtype: Response
         """
-        sftp = self._ssh.open_sftp()
-        sftp.put(source, destination)
-        # todo add callback to fill real response values from async sftp put
-        return EmptyResponse()
+        # Avoid any ssh known_hosts prompts.
+        command = 'scp -o StrictHostKeyChecking=no {} {}:{}'.format(source, self._host_string(), destination)
+        self._logger.debug('SCP popen blocking [{}:{}]: {}'.format(self.user, self.host, command))
+        proc = Popen(command,shell=True, stdout=PIPE, stderr=PIPE)
+        output, error = proc.communicate()
+        return Response(raw_output=output, raw_error=error, returncode=proc.returncode)
+
+    def _escaped_ssh_command(self, command):
+        """
+        :param command: the command to execute if it were local
+        :type command: str
+        :return: the escaped command wrapped around an ssh call
+        :rtype: str
+        """
+        escaped_command = command.replace("'", "\'")
+        # Avoid any ssh known_hosts prompts.
+        return "ssh -o StrictHostKeyChecking=no {} '{}'".format(self._host_string(), escaped_command)
+
+    def _host_string(self):
+        """
+        Return either the host, or the username@host if the username is specified.
+
+        :rtype: str
+        """
+        return self.host if self.user is None else "{}@{}".format(self.user, self.host)

--- a/app/util/shell/shell_client.py
+++ b/app/util/shell/shell_client.py
@@ -8,37 +8,6 @@ class ShellClient(object):
     def __init__(self, host, user):
         self.host = host
         self.user = user
-        self.connected = False
-
-    def connect(self):
-        """
-        Initializes the shell connection with the host
-        :return:
-        """
-        if not self.connected:
-            self.connected = True
-            self._connect_client()
-        else:
-            raise ConnectionError('Connection to host {} as user {} is already open'.format(self.host, self.user))
-
-    def _connect_client(self):
-        """ Put subclass implementation here """
-        pass
-
-    def close(self):
-        """
-        Closes the shell connection with the host
-        :return:
-        """
-        if self.connected:
-            self.connected = False
-            self._close_client()
-        else:
-            raise ConnectionAbortedError('Connection to host {} as user {}'.format(self.host, self.user))
-
-    def _close_client(self):
-        """ Put subclass implementation here """
-        pass
 
     @classmethod
     def is_localhost(cls, host):
@@ -64,12 +33,6 @@ class ShellClient(object):
         :return:
         :rtype: Response
         """
-        if not self.connected:
-            raise ConnectionError(
-                'Connection to host {}  as user {} is closed, unable to exececute command {}'.format(
-                    self.host, self.user, command
-                )
-            )
         if async and error_on_failure:
             raise NotImplementedError('async command execution and raising errors on failure is not implemented')
         elif async:
@@ -112,15 +75,6 @@ class ShellClient(object):
         :type destination: str
         :return:
         """
-        if not self.connected:
-            raise ConnectionError(
-                'Connection to host {}  as user {} is closed, unable to copy {} to {}'.format(
-                    self.host,
-                    self.user,
-                    source,
-                    destination
-                )
-            )
         return self._copy_on_client(source, destination)
 
     def _copy_on_client(self, source, destination):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ coverage==3.7.1
 cx_Freeze==4.3.3
 Logbook==0.7.0
 nose==1.3.3
-paramiko==1.15.1
 pexpect==3.3
 psutil==2.1.2
 pylint==1.3.1

--- a/test/unit/util/shell/test_remote_shell_client.py
+++ b/test/unit/util/shell/test_remote_shell_client.py
@@ -17,17 +17,6 @@ class TestRemoteShellClient(BaseUnitTestCase):
         super().setUp()
         self.mock_socket = self.patch('app.util.shell.shell_client.socket')
         self.mock_Popen = self.patch('app.util.shell.local_shell_client.Popen')
-        self.mock_SSHClient = self.patch('app.util.shell.remote_shell_client.SSHClient')
-        self.mock_AutoAddPolicy = self.patch('app.util.shell.remote_shell_client.AutoAddPolicy')
-
-    def test_connect(self):
-        client = RemoteShellClient(self._HOST, self._USER)
-        client.connect()
-
-    def test_close(self):
-        client = RemoteShellClient(self._HOST, self._USER)
-        client.connect()
-        client.close()
 
     @genty_dataset(
         normal_response=(False, Response(raw_output='\ncat'.encode(), raw_error='\ndog'.encode())),


### PR DESCRIPTION
Paramiko is very strict about authentication, and we cannot figure out what configuration settings we must set in order to have ssh calls work with hosts that have properly configured keys. So we are replacing Paramiko with bare ssh calls from Popen.

this commit fixes #16 
