### PR TITLE
Fix incorrect conversion of string to list in ConfigLoader

### DIFF
--- a/app/util/conf/base_config_loader.py
+++ b/app/util/conf/base_config_loader.py
@@ -162,7 +162,7 @@ class BaseConfigLoader(object):
             # The ConfigObj library converts comma delimited strings to lists.  In the case on a single element, we
             # need to do the conversion ourselves.
             if type(value) is not list:
-                value = list(value)
+                value = [value]
             config.set(key, value)
         else:  # Could be str or NoneType, we assume it should be a str
             # Hacky: If the value starts with ~, we assume it's a path that needs to be expanded

--- a/test/unit/util/conf/test_base_config_loader.py
+++ b/test/unit/util/conf/test_base_config_loader.py
@@ -1,0 +1,19 @@
+from app.util.conf.base_config_loader import BaseConfigLoader
+from app.util.conf.configuration import Configuration
+from test.framework.base_unit_test_case import BaseUnitTestCase
+
+
+class TestBaseConfigLoader(BaseUnitTestCase):
+
+    def test_list_type_conf_file_values_are_correctly_converted_to_lists(self):
+        conf = Configuration.singleton()
+        conf.set('some_list', ['localhost'])  # The previous conf value determines the expected type: a list.
+        conf_file_value = 'my-lonely-slave'  # ConfigObj parses value to a string type if only one element is specified.
+
+        config_loader = BaseConfigLoader()
+        config_loader._cast_and_set('some_list', conf_file_value, conf)
+
+        expected_conf_setting = [conf_file_value]
+        self.assertListEqual(conf.get('some_list'), expected_conf_setting,
+                             'The config loader should convert string values into single element lists for conf keys '
+                             'that are expected to be of type list.')


### PR DESCRIPTION
Casting a string to a list in Python (via `list('hello')`) creates a
list consisting of each character in the string.

We had code in BaseConfigLoader to convert a conf value into a list
when a list was expected, but the conversion was incorrect. The
expected behavior is that a single-element list is created containing
the original value (e.g., ['hello'], not ['h', 'e', 'l', 'l', 'o']).
