### PR TITLE
Auto-add hosts to known_hosts on git clone

### DIFF
--- a/app/util/conf/base_config_loader.py
+++ b/app/util/conf/base_config_loader.py
@@ -76,6 +76,9 @@ class BaseConfigLoader(object):
         conf.set('master_port', '43000')
         conf.set('slaves', ['localhost'])
 
+        # Strict host key checking on git remote operations, disabled by default
+        conf.set('git_strict_host_key_checking', False)
+
         # CORS support - a regex to match against allowed API request origins, or None to disable CORS
         conf.set('cors_allowed_origins_regex', None)
 
@@ -122,6 +125,7 @@ class BaseConfigLoader(object):
             'master_port',
             'log_filename',
             'eventlog_filename',
+            'git_strict_host_key_checking',
             'cors_allowed_origins_regex',
         ]
         try:

--- a/conf/default_clusterrunner.conf
+++ b/conf/default_clusterrunner.conf
@@ -20,6 +20,9 @@
 ## The hostname to refer to the local machine with
 # hostname = localhost
 
+## Should we automatically reject all git remote operations on hosts that are not in known_hosts?
+# git_strict_host_key_checking = False
+
 ## CORS support - a regex to match against allowed API request origins, or None to disable CORS
 # cors_allowed_origins_regex = None
 

--- a/test/unit/project_type/test_git.py
+++ b/test/unit/project_type/test_git.py
@@ -1,3 +1,5 @@
+import pexpect
+
 from app.project_type.git import Git
 from app.util.conf.configuration import Configuration
 from test.framework.base_unit_test_case import BaseUnitTestCase
@@ -7,10 +9,13 @@ class TestGit(BaseUnitTestCase):
 
     def setUp(self):
         self.patch('app.project_type.git.fs.create_dir')
+        self.patch('os.symlink')
+        self.mock_pexpect_child = self.patch('pexpect.spawn').return_value
+        self.mock_pexpect_child.before = 'None'
+        self.mock_pexpect_child.exitstatus = 0
         super().setUp()
 
     def test_timing_file_path_happy_path(self):
-        self.patch('os.symlink')
         git_env = Git("ssh://scm.dev.box.net/box/www/current", 'origin', 'refs/changes/78/151978/27')
         timing_file = git_env.timing_file_path('QUnit')
         self.assertEquals(
@@ -20,7 +25,6 @@ class TestGit(BaseUnitTestCase):
         )
 
     def test_execute_command_in_project_specifies_cwd_if_exists(self):
-        self.patch('os.symlink')
         os_path_exists_patch = self.patch('os.path.exists')
         os_path_exists_patch.return_value = True
         project_type_popen_patch = self.patch('app.project_type.project_type.Popen')
@@ -39,7 +43,6 @@ class TestGit(BaseUnitTestCase):
         )
 
     def test_execute_command_in_project_type_specifies_cwd_if_doesnt_exist(self):
-        self.patch('os.symlink')
         os_path_exists_patch = self.patch('os.path.exists')
         os_path_exists_patch.return_value = False
         project_type_popen_patch = self.patch('app.project_type.project_type.Popen')
@@ -56,3 +59,47 @@ class TestGit(BaseUnitTestCase):
             shell=True,
             stdout=-1
         )
+
+    def test_execute_git_remote_command_auto_adds_known_host_if_prompted(self):
+        prompted = False
+
+        def expect_side_effect(*args, **kwargs):
+            nonlocal prompted
+
+            if args[0] == ['^User.*: ', '^Pass.*: ', '.*Are you sure you want to continue connecting.*'] \
+                    and not prompted:
+                prompted = True
+                return 2
+            elif args[0] == pexpect.EOF:
+                return 0
+
+            raise pexpect.TIMEOUT('some_msg')
+
+        self.mock_pexpect_child.expect.side_effect = expect_side_effect
+        Configuration['git_strict_host_key_checking'] = False
+        git = Git("some_remote_value", 'origin', 'ref/to/some/branch')
+        git._execute_git_remote_command('some_command')
+        self.mock_pexpect_child.sendline.assert_called_with("yes")
+
+    def test_execute_git_remote_command_doesnt_auto_add_known_host_if_no_prompt(self):
+        def expect_side_effect(*args, **kwargs):
+            if args[0] == ['^User.*: ', '^Pass.*: ', '.*Are you sure you want to continue connecting.*']:
+                raise pexpect.TIMEOUT('some_msg')
+            return None
+
+        self.mock_pexpect_child.expect.side_effect = expect_side_effect
+        git = Git("some_remote_value", 'origin', 'ref/to/some/branch')
+        git._execute_git_remote_command('some_command')
+        self.assertEquals(self.mock_pexpect_child.sendline.call_count, 0)
+
+    def test_execute_git_remote_command_raises_exception_if_strict_host_checking_and_prompted(self):
+        def expect_side_effect(*args, **kwargs):
+            if args[0] == ['^User.*: ', '^Pass.*: ', '.*Are you sure you want to continue connecting.*']:
+                return 2
+            return None
+
+        self.mock_pexpect_child.expect.side_effect = expect_side_effect
+        Configuration['git_strict_host_key_checking'] = True
+        git = Git("some_remote_value", 'origin', 'ref/to/some/branch')
+        self.assertRaises(RuntimeError, git._execute_git_remote_command, 'some_command')
+


### PR DESCRIPTION
Currently, we reject any host that isn't in the known_hosts file upon
git cloning for security reasons. However, because of the new security
measures (hmac digest validation on all requests + 600 permissions on
the clusterrunner.conf file) we have determined this restriction is no
longer necessary.
