### PR TITLE
Disable argparse argument abbreviations

### DIFF
--- a/app/util/argument_parsing.py
+++ b/app/util/argument_parsing.py
@@ -28,6 +28,26 @@ class ClusterRunnerArgumentParser(argparse.ArgumentParser):
         target_arg_group = self._required_arg_group if is_required else self._optional_arg_group
         target_arg_group.add_argument(*args, **kwargs)
 
+    def _get_option_tuples(self, option_string):
+        """
+        This method is overridden explicitly to disable argparse prefix matching. Prefix matching is an undesired
+        default behavior as it creates the potential for unintended breaking changes just by adding a new command-line
+        argument.
+
+        For example, if a user uses the argument "--master" to specify a value for "--master-url", and later we add a
+        new argument named "--master-port", that change will break the user script that used "--master".
+
+        See: https://docs.python.org/3.4/library/argparse.html#argument-abbreviations-prefix-matching
+        """
+        # This if statement comes from the superclass implementation -- it precludes a code path in the superclass
+        # that is responsible for checking for argument prefixes. The return value of an empty list is the way that
+        # this method communicates no valid arguments were found.
+        chars = self.prefix_chars
+        if option_string[0] in chars and option_string[1] in chars:
+            return []
+
+        return super()._get_option_tuples(option_string)
+
 
 class ClusterRunnerHelpFormatter(argparse.HelpFormatter):
     def _get_help_string(self, action):

--- a/test/framework/functional_test_cluster.py
+++ b/test/framework/functional_test_cluster.py
@@ -154,7 +154,7 @@ class FunctionalTestCluster(object):
                 'slave',
                 '--port', str(slave_port),
                 '--num-executors', str(num_executors_per_slave),
-                '--master', '{}:{}'.format(self.master.host, self.master.port),
+                '--master-url', '{}:{}'.format(self.master.host, self.master.port),
                 '--eventlog-file', slave_eventlog,
                 '--config-file', self._conf_file_path,
             ]

--- a/test/unit/test_main.py
+++ b/test/unit/test_main.py
@@ -149,6 +149,29 @@ class TestMain(BaseUnitTestCase):
             self.assertTrue(has_argument_help_text,
                             'All arguments (including "{}") should have help text specified.'.format(argument_name))
 
+    @genty_dataset(
+        ['-V'], ['--version'], ['master'], ['slave', '-p', '12345'], ['build', '--master-url', 'shire.middle-earth.org']
+    )
+    def test_parse_args_accepts_valid_arguments(self, valid_arg_set):
+        try:
+            main._parse_args(valid_arg_set)  # Test succeeds if no exception is raised.
+        except SystemExit as ex:
+            if ex.code != 0:  # Test also succeeds if SystemExit is raised with "successful" exit code of 0.
+                raise
+
+    @genty_dataset(
+        no_args=([],),
+        prefix_of_valid_arg=(['slave', '--master', 'shire.middle-earth.org'],),
+        nonexistent_arg=(['hobbitses'],),
+    )
+    def test_parse_args_rejects_invalid_arguments(self, invalid_arg_set):
+        rgx_anything_but_zero = r'[^0]'
+        with self.assertRaisesRegex(
+                SystemExit, rgx_anything_but_zero,
+                msg='Executing _parse_args on a set of invalid args should raise SystemExit with a non-zero exit code.'
+        ):
+            main._parse_args(invalid_arg_set)
+
     def mock_cwd(self, current_dir=None):
         mock_os = self.patch('app.subcommands.build_subcommand.os')
         mock_os.getcwd.return_value = current_dir or self._PROJECT_DIRECTORY


### PR DESCRIPTION
The argparse library does prefix matching by default. For example, a
user can specify "--master" at the command line instead of
"--master-url", as long as the prefix is unambiguous.

Prefix matching is actually an undesired default behavior for us as it
creates the potential for unintended breaking changes just by adding a
new command-line argument.

For example, if a user uses the argument "--master" to specify a value
for "--master-url", and later we add a new argument named
"--master-port", that change will break the user script that used
"--master".

This change disables prefix matching in argparse.
