### PR TITLE
Use new Network.are_host_same() equivalency check

### DIFF
--- a/app/subcommands/build_subcommand.py
+++ b/app/subcommands/build_subcommand.py
@@ -6,6 +6,7 @@ from app.client.service_runner import ServiceRunner, ServiceRunError
 from app.subcommands.subcommand import Subcommand
 from app.util import log
 from app.util.conf.configuration import Configuration
+from app.util.network import Network
 from app.util.secret import Secret
 
 
@@ -37,8 +38,9 @@ class BuildSubcommand(Subcommand):
         operational_master_url = master_url or '{}:{}'.format(Configuration['hostname'], Configuration['port'])
 
         # If running a single master, single slave--both on localhost--we need to launch services locally.
-        if master_url is None and Configuration['master_hostname'] == 'localhost'\
-                and len(Configuration['slaves']) == 1 and Configuration['slaves'][0] == 'localhost':
+        if master_url is None and Network.are_hosts_same(Configuration['master_hostname'], 'localhost') \
+                and len(Configuration['slaves']) == 1 \
+                and Network.are_hosts_same(Configuration['slaves'][0], 'localhost'):
             self._start_local_services(operational_master_url)
 
         if request_params['type'] == 'directory':

--- a/app/util/network.py
+++ b/app/util/network.py
@@ -119,12 +119,16 @@ class Network(object):
             are the same host.
         :rtype: bool
         """
-        host_a_rsa_key = Network._rsa_key(host_a)
+        # For efficiency's sake, skip the rsa key check if the host strings are identical
+        if host_a == host_b and host_a is not None:
+            return True
+
+        host_a_rsa_key = Network.rsa_key(host_a)
 
         if host_a_rsa_key is None:
             return False
 
-        host_b_rsa_key = Network._rsa_key(host_b)
+        host_b_rsa_key = Network.rsa_key(host_b)
 
         if host_b_rsa_key is None:
             return False
@@ -132,7 +136,7 @@ class Network(object):
         return host_a_rsa_key == host_b_rsa_key
 
     @staticmethod
-    def _rsa_key(host):
+    def rsa_key(host):
         """
         :param host: The RSA key for host that we want to retrieve
         :type host: str
@@ -143,7 +147,7 @@ class Network(object):
         output, error = proc.communicate()
 
         if proc.returncode != 0:
-            log.get_logger(__name__).error('Failed to get rsa string with error: {}'.format(error))
+            log.get_logger(__name__).error('Failed to get rsa string with output: {}, error: {}'.format(output, error))
             return None
 
         line = output.decode("utf-8")

--- a/app/util/shell/factory.py
+++ b/app/util/shell/factory.py
@@ -1,4 +1,4 @@
-from app.util.shell.shell_client import ShellClient
+from app.util.network import Network
 from app.util.shell.local import LocalShellClient
 from app.util.shell.remote import RemoteShellClient
 
@@ -6,7 +6,7 @@ from app.util.shell.remote import RemoteShellClient
 class ShellClientFactory(object):
     @classmethod
     def create(cls, host, user):
-        if ShellClient.is_localhost(host):
+        if Network.are_hosts_same(host, 'localhost'):
             return LocalShellClient(host, user)
         else:
             return RemoteShellClient(host, user)

--- a/app/util/shell/shell_client.py
+++ b/app/util/shell/shell_client.py
@@ -1,6 +1,3 @@
-import socket
-
-
 class ShellClient(object):
     """
     Shell Client interface
@@ -8,18 +5,6 @@ class ShellClient(object):
     def __init__(self, host, user):
         self.host = host
         self.user = user
-
-    @classmethod
-    def is_localhost(cls, host):
-        """
-        :param host:
-        :return:
-        :rtype: bool
-        """
-        return (
-            'localhost' == host or
-            socket.gethostbyname(host) == socket.gethostbyname(socket.gethostname())
-        )
 
     def exec_command(self, command, async=False, error_on_failure=False):
         """

--- a/test/unit/subcommands/test_deploy_subcommand.py
+++ b/test/unit/subcommands/test_deploy_subcommand.py
@@ -1,6 +1,5 @@
-import socket
-
 from app.subcommands.deploy_subcommand import DeploySubcommand
+from app.util.network import Network
 from test.framework.base_unit_test_case import BaseUnitTestCase
 
 
@@ -19,22 +18,12 @@ class TestDeploySubcommand(BaseUnitTestCase):
         deploy_subcommand = DeploySubcommand()
         deploy_subcommand._binaries_tar('clusterrunner', '~/.clusterrunner/dist')
 
-    def test_deploy_binaries_and_conf_does_nothing_if_socket_gaierror_raised(self):
-        mock_DeployTarget = self.patch('app.subcommands.deploy_subcommand.DeployTarget')
-        mock_DeployTarget.side_effect = socket.gaierror()
-        mock_DeployTarget_instance = mock_DeployTarget.return_value
-        deploy_subcommand = DeploySubcommand()
-        deploy_subcommand._deploy_binaries_and_conf(
-            ['host_1'], 'invalid_host', 'username', 'exec', '/path/to/exec', '/path/to/conf')
-        self.assertFalse(mock_DeployTarget_instance.deploy_binary.called)
-        self.assertFalse(mock_DeployTarget_instance.deploy_conf.called)
-
     def test_deploy_binaries_and_conf_deploys_both_conf_and_binary_for_remote_host(self):
         mock_DeployTarget = self.patch('app.subcommands.deploy_subcommand.DeployTarget')
         mock_DeployTarget_instance = mock_DeployTarget.return_value
         deploy_subcommand = DeploySubcommand()
         deploy_subcommand._deploy_binaries_and_conf(
-            ['remote_host'], 'taejun', 'username', 'exec', '/path/to/exec', '/path/to/conf')
+            ['remote_host'], 'username', 'exec', '/path/to/exec', '/path/to/conf')
         self.assertTrue(mock_DeployTarget_instance.deploy_binary.called)
         self.assertTrue(mock_DeployTarget_instance.deploy_conf.called)
 
@@ -44,7 +33,7 @@ class TestDeploySubcommand(BaseUnitTestCase):
         mock_DeployTarget_instance = mock_DeployTarget.return_value
         deploy_subcommand = DeploySubcommand()
         deploy_subcommand._deploy_binaries_and_conf(
-            ['localhost'], 'taejun', 'username', 'exec', '/path/to/exec', '/home/.clusterrunner/clusterrunner.conf')
+            ['localhost'], 'username', 'exec', '/path/to/exec', '/home/.clusterrunner/clusterrunner.conf')
         self.assertFalse(mock_DeployTarget_instance.deploy_conf.called)
 
     def test_deploy_binaries_and_conf_deploys_conf_if_localhost_with_diff_in_use_conf(self):
@@ -54,7 +43,6 @@ class TestDeploySubcommand(BaseUnitTestCase):
         deploy_subcommand = DeploySubcommand()
         deploy_subcommand._deploy_binaries_and_conf(
             ['localhost'],
-            'taejun',
             'username',
             'exec',
             '/path/to/exec',
@@ -69,7 +57,6 @@ class TestDeploySubcommand(BaseUnitTestCase):
         deploy_subcommand = DeploySubcommand()
         deploy_subcommand._deploy_binaries_and_conf(
             ['localhost'],
-            'taejun',
             'username',
             '/home/.clusterrunner/dist/clusterrunner_rime',
             '/home/.clusterrunner/clusterrunner.tgz',
@@ -84,10 +71,72 @@ class TestDeploySubcommand(BaseUnitTestCase):
         deploy_subcommand = DeploySubcommand()
         deploy_subcommand._deploy_binaries_and_conf(
             ['localhost'],
-            'taejun',
             'username',
             '/home/.clusterrunner/dist/clusterrunner',
             '/home/.clusterrunner/clusterrunner.tgz',
             '/clusterrunner.conf'
         )
         self.assertFalse(mock_DeployTarget_instance.deploy_binary.called)
+
+    def test_non_registered_slaves_returns_empty_list_if_all_registered(self):
+        registered_hosts = ['host_1', 'host_2']
+        slaves_to_validate = ['host_1', 'host_2']
+
+        def rsa_key(*args, **kwargs):
+            if args[0] == 'host_1':
+                return 'rsa_key_1'
+            elif args[0] == 'host_2':
+                return 'rsa_key_2'
+            else:
+                return 'blah'
+
+        old_rsa_key = Network.rsa_key
+        Network.rsa_key = rsa_key
+        deploy_subcommand = DeploySubcommand()
+        non_registered = deploy_subcommand._non_registered_slaves(registered_hosts, slaves_to_validate)
+        Network.rsa_key = old_rsa_key
+        self.assertEquals(0, len(non_registered))
+
+    def test_non_registered_slaves_returns_non_registered_slaves(self):
+        registered_hosts = ['host_1', 'host_3']
+        slaves_to_validate = ['host_1', 'host_2', 'host_3', 'host_4']
+
+        def rsa_key(*args, **kwargs):
+            if args[0] == 'host_1':
+                return 'rsa_key_1'
+            elif args[0] == 'host_2':
+                return 'rsa_key_2'
+            elif args[0] == 'host_3':
+                return 'rsa_key_3'
+            elif args[0] == 'host_4':
+                return 'rsa_key_4'
+            else:
+                return 'blah'
+
+        self.patch('app.util.network.Network.rsa_key', new=rsa_key)
+        deploy_subcommand = DeploySubcommand()
+        non_registered = deploy_subcommand._non_registered_slaves(registered_hosts, slaves_to_validate)
+        self.assertEquals(len(non_registered), 2)
+        self.assertTrue('host_2' in non_registered)
+        self.assertTrue('host_4' in non_registered)
+
+    def test_non_registered_slaves_returns_empty_list_with_slaves_with_same_rsa_keys_but_different_names(self):
+        registered_hosts = ['host_1_alias', 'host_2_alias']
+        slaves_to_validate = ['host_1', 'host_2']
+
+        def rsa_key(*args, **kwargs):
+            if args[0] == 'host_1':
+                return 'rsa_key_1'
+            elif args[0] == 'host_2':
+                return 'rsa_key_2'
+            elif args[0] == 'host_1_alias':
+                return 'rsa_key_1'
+            elif args[0] == 'host_2_alias':
+                return 'rsa_key_2'
+            else:
+                return 'blah'
+
+        self.patch('app.util.network.Network.rsa_key', new=rsa_key)
+        deploy_subcommand = DeploySubcommand()
+        non_registered = deploy_subcommand._non_registered_slaves(registered_hosts, slaves_to_validate)
+        self.assertEquals(0, len(non_registered))

--- a/test/unit/util/shell/test_shell_client.py
+++ b/test/unit/util/shell/test_shell_client.py
@@ -53,21 +53,6 @@ class TestShellClient(BaseUnitTestCase):
         with self.assertRaises(ConnectionError):
             client.copy('src', 'dest')
 
-    @genty_dataset(
-        on_localhost=('localhost', 'localhost', True),
-        negative_test=('redfield', 'localhost', False),
-        same_hostname=('redfield', 'redfield', True),
-        alias_localhost=('welkers-mbp', 'localhost', True)
-    )
-    def test_is_localhost(self, query_hostname, local_hostname, expected):
-        self.mock_gethostbyname_rvals({
-            'redfield': '89.24.141.211',
-            'kennedy': '173.78.183.223',
-            'localhost': '127.0.0.1',
-        })
-        self.mock_hostname_of_local_machine(local_hostname)
-        self.assertEqual(expected, ShellClient.is_localhost(query_hostname))
-
     def mock_gethostbyname_rvals(self, host_addr_map):
         """Maps hostname to ip addresses, and defaults to loopback address"""
         self.mock_socket.gethostbyname = lambda x: host_addr_map.get(x, '127.0.0.1')

--- a/test/unit/util/test_network.py
+++ b/test/unit/util/test_network.py
@@ -7,12 +7,12 @@ from test.framework.base_unit_test_case import BaseUnitTestCase
 class TestNetwork(BaseUnitTestCase):
     def test_rsa_key_returns_none_if_ssh_keyscan_error(self):
         self._patch_popen_call_to_ssh_keyscan(1, 'some_output', 'some_error"')
-        rsa_key = Network._rsa_key('some_host_that_causes_it_to_fail')
+        rsa_key = Network.rsa_key('some_host_that_causes_it_to_fail')
         self.assertIsNone(rsa_key)
 
     def test_rsa_key_returns_output_without_ssh_rsa_str(self):
         self._patch_popen_call_to_ssh_keyscan(0, b"a_host ssh-rsa thebytearray", None)
-        rsa_key = Network._rsa_key('a_host')
+        rsa_key = Network.rsa_key('a_host')
         self.assertEquals(rsa_key, 'thebytearray')
 
     def test_are_hosts_same_returns_false_if_rsa_key_is_none(self):


### PR DESCRIPTION
Replace the existing "is localhost" checks with the new, more reliable method.

Also, update the slave-registration validation logic to use the rsa_keys as the unique identifier for a host, rather than the hostname. This PR should significantly improve "clusterrunner deploy" robustness.
