### PR TITLE
Kill child processes on build teardown

### DIFF
--- a/app/project_type/docker.py
+++ b/app/project_type/docker.py
@@ -134,6 +134,13 @@ class Docker(ProjectType):
             "{}.timing.json".format(job_name)
         )
 
+    def kill_subprocesses(self):
+        """
+        Signal the environment that any currently running subprocesses should be terminated. This is a no-op for Docker
+        environments since we can just kill the entire container.
+        """
+        pass
+
     def _remove_file_system_unfriendly_characters(self, unescaped_path):
         """
         Escape the string unescaped_path to be POSIX directory format compliant.

--- a/app/slave/cluster_slave.py
+++ b/app/slave/cluster_slave.py
@@ -138,6 +138,10 @@ class ClusterSlave(object):
         Called from teardown_build(). Do asynchronous teardown for the build so that we can make the call to
         teardown_build() non-blocking. Also take care of posting back to the master when teardown is complete.
         """
+        # Kill all executors' processes. This only has an effect if we are tearing down before a build completes.
+        for executor in self.executors.values():
+            executor.kill()
+
         if self._project_type:
             self._project_type.teardown_build()
             self._logger.info('Build teardown complete for build {}.', self._current_build_id)

--- a/app/slave/subjob_executor.py
+++ b/app/slave/subjob_executor.py
@@ -102,6 +102,13 @@ class SubjobExecutor(object):
 
         return tarfile_path
 
+    def kill(self):
+        """
+        Shutdown this executor. Kill any subprocesses the executor is currently executing.
+        """
+        if self._project_type:
+            self._project_type.kill_subprocesses()
+
     def _execute_atom_command(self, atomic_command, atom_environment_vars, atom_artifact_dir):
         """
         Run the main command for this atom. Output the command, console output and exit code to

--- a/test/framework/base_unit_test_case.py
+++ b/test/framework/base_unit_test_case.py
@@ -113,6 +113,7 @@ class BaseUnitTestCase(TestCase):
         safeguarded_packages = {
             'filesystem side effects': [
                 'os.chmod',
+                'os.killpg',
                 'os.makedirs',
                 'os.remove',
                 'os.rename',

--- a/test/unit/project_type/test_git.py
+++ b/test/unit/project_type/test_git.py
@@ -1,3 +1,4 @@
+from unittest.mock import ANY
 import pexpect
 
 from app.project_type.git import Git
@@ -36,10 +37,11 @@ class TestGit(BaseUnitTestCase):
         git_env.execute_command_in_project('some_command')
         project_type_popen_patch.assert_called_once_with(
             'export PROJECT_DIR="proj_dir"; some_command',
-            stderr=-2,
             cwd='proj_dir',
-            shell=True,
-            stdout=-1
+            shell=ANY,
+            stdout=ANY,
+            stderr=ANY,
+            start_new_session=ANY,
         )
 
     def test_execute_command_in_project_type_specifies_cwd_if_doesnt_exist(self):
@@ -54,10 +56,11 @@ class TestGit(BaseUnitTestCase):
         git_env.execute_command_in_project('some_command')
         project_type_popen_patch.assert_called_once_with(
             'export PROJECT_DIR="proj_dir"; some_command',
-            stderr=-2,
             cwd=None,
-            shell=True,
-            stdout=-1
+            shell=ANY,
+            stdout=ANY,
+            stderr=ANY,
+            start_new_session=ANY,
         )
 
     def test_execute_git_remote_command_auto_adds_known_host_if_prompted(self):


### PR DESCRIPTION
This adds functionality in the teardown_build flow on the slave that
will kill any child processes that are still executing. This is
important because if the slave is terminated, we don't want it to
leave orphaned processes that are still doing real work.

This has no effect on the teardown that is initiated by the master
when all subjobs are complete -- at that point all child processes
have ended normally. This only has an effect when the slave is
terminated while executing a job.
