### PR TITLE
Improve the robustness of the deployment via a few methods:

### DIFF
--- a/app/deployment/remote_master_service.py
+++ b/app/deployment/remote_master_service.py
@@ -1,3 +1,5 @@
+import time
+
 from app.client.service_runner import ServiceRunner
 from app.deployment.remote_service import RemoteService
 
@@ -7,7 +9,9 @@ class RemoteMasterService(RemoteService):
     This class serves to start the master service remotely.
     """
     # Number of seconds to wait for master service to respond after starting
-    _MASTER_SERVICE_TIMEOUT_SEC = 5
+    _MASTER_SERVICE_TIMEOUT_SEC = 10
+    # The number of times to retry starting the master daemon
+    _MASTER_SERVICE_START_RETRIES = 3
 
     def start_and_block_until_up(self, port, timeout_sec=_MASTER_SERVICE_TIMEOUT_SEC):
         """
@@ -19,11 +23,54 @@ class RemoteMasterService(RemoteService):
         :param timeout_sec: number of seconds to wait for the master to respond before timing out
         :type timeout_sec: int
         """
-        self._shell_client.exec_command('nohup {} master --port {} &'.format(self._executable_path, str(port)),
-                                        async=True)
+        # Start the master service daemon
+        master_service_cmd = 'nohup {} master --port {} &'.format(self._executable_path, str(port))
+
+        # There are cases when 'clusterrunner deploy' fails, and there is no clusterrunner master service process
+        # to be seen--but the fix is to just re-run the command.
+        for i in range(self._MASTER_SERVICE_START_RETRIES):
+            self._shell_client.exec_command(master_service_cmd, async=True)
+            # Give the service a second to start up
+            time.sleep(1)
+
+            if self._is_process_running(self._executable_path):
+                break
+            else:
+                self._logger.warning('Master service process failed to start on try {}, host {}'.format(i, self.host))
+
+        if not self._is_process_running(self._executable_path):
+            self._logger.error('Master service process failed to start on host {}.'.format(self.host))
+            raise SystemExit(1)
+
+        # Check to see if the master service is responding to http requests
         master_service_url = '{}:{}'.format(self.host, str(port))
-        master_service = ServiceRunner(master_service_url)
+        master_service = ServiceRunner(master_service_url, main_executable=self._executable_path)
 
         if not master_service.is_up(master_service_url, timeout=timeout_sec):
-            self._logger.error('Master service running on {} failed to start.'.format(master_service_url))
+            self._logger.error('Master service process exists on {}, but service on {} failed to respond.'.format(
+                self.host, master_service_url))
             raise SystemExit(1)
+
+    def _is_process_running(self, command):
+        """
+        Is a process that contains the string command running on the remote host?
+
+        :param command: The command substring to search for.
+        :type command: str
+        :rtype: bool
+        """
+        # Replace first char of command, 'n', with '[n]' to prevent the grep call from showing up in search results
+        command = '[{}]'.format(command[0]) + command[1:]
+
+        # Because this shell_client call can potentially be remote, we cannot use the psutil library, and
+        # must instead perform shell commands directly.
+        ps_search_cmd = 'ps ax | grep \'{}\''.format(command)
+        ps_search_response = self._shell_client.exec_command(ps_search_cmd, async=False)
+        output = ps_search_response.raw_output.decode("utf-8").split("\n")
+
+        for output_line in output:
+            if len(output_line.strip()) == 0:
+                continue
+            return True
+
+        return False

--- a/app/deployment/remote_service.py
+++ b/app/deployment/remote_service.py
@@ -27,5 +27,8 @@ class RemoteService(object):
         Stop all clusterrunner services on this machine. This functionality is in the base class because it
         should be common across all possible subclasses.
         """
-        self._shell_client.exec_command('{} stop'.format(self._executable_path), async=False)
+        response = self._shell_client.exec_command('{} stop'.format(self._executable_path), async=False)
 
+        if not response.is_success():
+            self._logger.error('clusterrunner stop failed on host {} with output: {}, error: {}'.format(
+                self.host, response.raw_output, response.raw_error))

--- a/test/unit/deployment/test_remote_master_service.py
+++ b/test/unit/deployment/test_remote_master_service.py
@@ -1,17 +1,67 @@
+from unittest.mock import Mock
+
 from app.deployment.remote_master_service import RemoteMasterService
 from test.framework.base_unit_test_case import BaseUnitTestCase
 
 
 class TestRemoteMasterService(BaseUnitTestCase):
-    def test_start_and_block_until_up_raises_exception_if_master_service_not_up(self):
-        self.patch('app.deployment.remote_service.ShellClientFactory')
+    def setUp(self):
+        super().setUp()
+        self.patch('time.sleep')
+
+    def test_start_and_block_until_up_raises_exception_if_process_fails_to_start(self):
+        self._mock_shell_exec_command({
+            'nohup some_path master --port 43000 &': "\n",
+            'ps ax | grep \'[s]ome_path\'': "\n",
+        })
+        remote_master_service = RemoteMasterService('some_host', 'some_username', 'some_path')
+        with self.assertRaisesRegex(SystemExit, '1'):
+            remote_master_service.start_and_block_until_up(43000, 5)
+
+    def test_start_and_block_until_up_raises_exception_if_process_starts_by_service_doesnt_respond(self):
+        self._mock_shell_exec_command({
+            'nohup some_path master --port 43000 &': "\n",
+            'ps ax | grep \'[s]ome_path\'': "\nsome_path\n",
+        })
         self.patch('app.deployment.remote_master_service.ServiceRunner').return_value.is_up.return_value = False
         remote_master_service = RemoteMasterService('some_host', 'some_username', 'some_path')
         with self.assertRaisesRegex(SystemExit, '1'):
             remote_master_service.start_and_block_until_up(43000, 5)
 
     def test_start_and_block_until_up_doesnt_raise_exception_if_master_service_is_up(self):
-        self.patch('app.deployment.remote_service.ShellClientFactory')
+        self._mock_shell_exec_command({
+            'nohup some_path master --port 43000 &': "\n",
+            'ps ax | grep \'[s]ome_path\'': "\nsome_path\n",
+        })
         self.patch('app.deployment.remote_master_service.ServiceRunner').return_value.is_up.return_value = True
         remote_master_service = RemoteMasterService('some_host', 'some_username', 'some_path')
         remote_master_service.start_and_block_until_up(43000, 5)
+
+    def test_is_process_running_returns_false_if_only_empty_output(self):
+        self._mock_shell_exec_command({'ps ax | grep \'[s]ome_command\'': "\n"})
+        remote_master_service = RemoteMasterService('some_host', 'some_username', 'some_path')
+        self.assertFalse(remote_master_service._is_process_running('some_command'))
+
+    def test_is_process_running_returns_true_if_found_non_empty_output(self):
+        self._mock_shell_exec_command({'ps ax | grep \'[s]ome_command\'': "\nrealoutput\n"})
+        remote_master_service = RemoteMasterService('some_host', 'some_username', 'some_path')
+        self.assertTrue(remote_master_service._is_process_running('some_command'))
+
+    def _mock_shell_exec_command(self, command_response_dict):
+        """
+        :param command_response_dict: a dictionary with the key being the expected input, and the value being the
+            raw output that will be returned.
+        :type command_response_dict: dict[str, str]
+        """
+        def exec_command(*args, **kwargs):
+            nonlocal command_response_dict
+            if args[0] in command_response_dict:
+                response_mock = Mock()
+                response_mock.raw_output = command_response_dict[args[0]].encode('utf-8')
+                response_mock.raw_error = None
+                response_mock.returncode = 0
+                return response_mock
+
+        shell_client_mock = self.patch('app.util.shell.remote.RemoteShellClient').return_value
+        shell_client_mock.exec_command.side_effect = exec_command
+        self.patch('app.deployment.remote_service.ShellClientFactory').create.return_value = shell_client_mock


### PR DESCRIPTION
- add retry logic for starting the master process
- shutdown existing slave services before the master service
- log an error when 'clusterrunner stop' fails
