### PR TITLE
Add more methods to unit test blacklist

### DIFF
--- a/test/unit/project_type/test_git.py
+++ b/test/unit/project_type/test_git.py
@@ -9,11 +9,12 @@ class TestGit(BaseUnitTestCase):
 
     def setUp(self):
         self.patch('app.project_type.git.fs.create_dir')
+        self.patch('os.unlink')
         self.patch('os.symlink')
+        super().setUp()
         self.mock_pexpect_child = self.patch('pexpect.spawn').return_value
         self.mock_pexpect_child.before = 'None'
         self.mock_pexpect_child.exitstatus = 0
-        super().setUp()
 
     def test_timing_file_path_happy_path(self):
         git_env = Git("ssh://scm.dev.box.net/box/www/current", 'origin', 'refs/changes/78/151978/27')

--- a/test/unit/subcommands/test_stop_subcommand.py
+++ b/test/unit/subcommands/test_stop_subcommand.py
@@ -8,10 +8,10 @@ from test.framework.base_unit_test_case import BaseUnitTestCase
 class TestStopSubcommand(BaseUnitTestCase):
 
     def setUp(self):
-        super().setUp()
         self.patch('os.remove')
-        self.patch('time.sleep')
         self.os_kill_patch = self.patch('os.kill')
+        super().setUp()
+        self.patch('time.sleep')
         self.os_path_exists_patch = self.patch('os.path.exists')
         self.psutil_pid_exists_patch = self.patch('psutil.pid_exists')
 

--- a/test/unit/test_main.py
+++ b/test/unit/test_main.py
@@ -33,6 +33,7 @@ class TestMain(BaseUnitTestCase):
         self.patch('main.SlaveConfigLoader')
         self.patch('app.util.conf.base_config_loader.platform').node.return_value = self._HOSTNAME
         self.patch('app.subcommands.master_subcommand.analytics.initialize')
+        self.patch('argparse._sys.stderr')  # Hack to prevent argparse from printing output during tests.
 
     def test_master_args_correctly_create_cluster_master(self):
         mock_cluster_master = self.mock_ClusterMaster.return_value  # get the mock for the ClusterMaster instance

--- a/test/unit/util/test_network.py
+++ b/test/unit/util/test_network.py
@@ -5,6 +5,9 @@ from test.framework.base_unit_test_case import BaseUnitTestCase
 
 
 class TestNetwork(BaseUnitTestCase):
+
+    _do_network_mocks = False  # Disable network-related patches (in BaseUnitTestCase) so we can test the patched code.
+
     def test_rsa_key_returns_none_if_ssh_keyscan_error(self):
         self._patch_popen_call_to_ssh_keyscan(1, 'some_output', 'some_error"')
         rsa_key = Network.rsa_key('some_host_that_causes_it_to_fail')


### PR DESCRIPTION
This change adds more methods to the unit test blacklist so that we
can more easily avoid filesystem effects and subprocess interaction
in our unit tests.
