### PR TITLE
Allow patching blacklisted methods after setUp()

### DIFF
--- a/test/unit/master/test_cluster_master.py
+++ b/test/unit/master/test_cluster_master.py
@@ -10,10 +10,9 @@ from test.framework.base_unit_test_case import BaseUnitTestCase
 class TestClusterMaster(BaseUnitTestCase):
 
     def setUp(self):
+        super().setUp()
         self.patch('app.util.fs.create_dir')
         self.patch('shutil.rmtree')
-        super().setUp()
-        self.patch('app.master.build.app.util')  # stub out util functions since these often interact with the fs
 
     def test_add_idle_slave_marks_build_finished_when_slaves_are_done(self):
         master = ClusterMaster()

--- a/test/unit/project_type/test_git.py
+++ b/test/unit/project_type/test_git.py
@@ -8,10 +8,10 @@ from test.framework.base_unit_test_case import BaseUnitTestCase
 class TestGit(BaseUnitTestCase):
 
     def setUp(self):
+        super().setUp()
         self.patch('app.project_type.git.fs.create_dir')
         self.patch('os.unlink')
         self.patch('os.symlink')
-        super().setUp()
         self.mock_pexpect_child = self.patch('pexpect.spawn').return_value
         self.mock_pexpect_child.before = 'None'
         self.mock_pexpect_child.exitstatus = 0

--- a/test/unit/subcommands/test_deploy_subcommand.py
+++ b/test/unit/subcommands/test_deploy_subcommand.py
@@ -5,8 +5,8 @@ from test.framework.base_unit_test_case import BaseUnitTestCase
 
 class TestDeploySubcommand(BaseUnitTestCase):
     def setUp(self):
-        self.patch('app.subcommands.deploy_subcommand.fs.compress_directory')
         super().setUp()
+        self.patch('app.subcommands.deploy_subcommand.fs.compress_directory')
 
     def test_binaries_tar_raises_exception_if_running_from_source(self):
         deploy_subcommand = DeploySubcommand()

--- a/test/unit/subcommands/test_stop_subcommand.py
+++ b/test/unit/subcommands/test_stop_subcommand.py
@@ -8,9 +8,9 @@ from test.framework.base_unit_test_case import BaseUnitTestCase
 class TestStopSubcommand(BaseUnitTestCase):
 
     def setUp(self):
+        super().setUp()
         self.patch('os.remove')
         self.os_kill_patch = self.patch('os.kill')
-        super().setUp()
         self.patch('time.sleep')
         self.os_path_exists_patch = self.patch('os.path.exists')
         self.psutil_pid_exists_patch = self.patch('psutil.pid_exists')

--- a/test/unit/test_main.py
+++ b/test/unit/test_main.py
@@ -20,8 +20,8 @@ class TestMain(BaseUnitTestCase):
     _PROJECT_DIRECTORY = 'workspace'
 
     def setUp(self):
-        self.patch('app.util.fs.write_file')
         super().setUp()
+        self.patch('app.util.fs.write_file')
         self.mock_tornado = self.patch('app.subcommands.service_subcommand.tornado')
         self.mock_ClusterMaster = self.patch('app.subcommands.master_subcommand.ClusterMaster')
         self.mock_ClusterSlave = self.patch('app.subcommands.slave_subcommand.ClusterSlave')


### PR DESCRIPTION
This change removes the requirement that methods from our unit test
method blacklist be patched before calling super().setUp() in a test
class.

This also allows blacklisted methods to now be patched in single tests
rather than needing to always be patched in setUp().
