### PR TITLE
Increase time on deploy to wait for master service to come up

### DIFF
--- a/app/deployment/remote_master_service.py
+++ b/app/deployment/remote_master_service.py
@@ -9,7 +9,7 @@ class RemoteMasterService(RemoteService):
     This class serves to start the master service remotely.
     """
     # Number of seconds to wait for master service to respond after starting
-    _MASTER_SERVICE_TIMEOUT_SEC = 10
+    _MASTER_SERVICE_TIMEOUT_SEC = 45
     # The number of times to retry starting the master daemon
     _MASTER_SERVICE_START_RETRIES = 3
 


### PR DESCRIPTION
Bumping it up from 5 sec to 45 seconds. After observing a deploy fail
just now, I have discovered that it WILL come up eventually, just 5
seconds is sometimes way too short of a timeout, as Joey had suggested
earlier.
