### PR TITLE
Make teardown better

### DIFF
--- a/app/master/cluster_master.py
+++ b/app/master/cluster_master.py
@@ -158,6 +158,7 @@ class ClusterMaster(object):
         # that will happen during slave allocation.
         slave = self.slave(slave_id)
         slave.is_alive = False
+        # todo: Fail any currently executing subjobs still executing on this slave.
         self._logger.info('Slave on {} was disconnected. (id: {})', slave.url, slave.id)
 
     def handle_request_for_new_build(self, build_params):

--- a/app/web_framework/cluster_slave_application.py
+++ b/app/web_framework/cluster_slave_application.py
@@ -115,14 +115,14 @@ class _SubjobHandler(_ClusterSlaveBaseHandler):
 class _ExecutorsHandler(_ClusterSlaveBaseHandler):
     def get(self):
         response = {
-            'executors': [executor.api_representation() for executor in self._cluster_slave.executors.values()]
+            'executors': [executor.api_representation() for executor in self._cluster_slave.executors_by_id.values()]
         }
         self.write(response)
 
 
 class _ExecutorHandler(_ClusterSlaveBaseHandler):
     def get(self, executor_id):
-        executor = self._cluster_slave.executors[int(executor_id)]
+        executor = self._cluster_slave.executors_by_id[int(executor_id)]
         response = {
             'executor': executor.api_representation()
         }

--- a/test/unit/project_type/test_project_type.py
+++ b/test/unit/project_type/test_project_type.py
@@ -15,6 +15,7 @@ class TestProjectType(BaseUnitTestCase):
     def setUp(self):
         super().setUp()
         self.mock_popen = self.patch('app.project_type.project_type.Popen').return_value
+        self.mock_killpg = self.patch('os.killpg')
 
     def test_required_constructor_args_are_correctly_detected_without_defaults(self):
         actual_required_args = _FakeEnvWithoutDefaultArgs.required_constructor_argument_names()
@@ -58,7 +59,7 @@ class TestProjectType(BaseUnitTestCase):
 
         project_type.teardown_build()
 
-        project_type.execute_command_in_project.assert_called_with('teardown')
+        project_type.execute_command_in_project.assert_called_with('teardown', timeout=None)
 
     def test_execute_command_in_project_does_not_choke_on_weird_command_output(self):
         some_weird_output = b'\xbf\xe2\x98\x82'  # the byte \xbf is invalid unicode
@@ -85,19 +86,8 @@ class TestProjectType(BaseUnitTestCase):
             self.assertEqual(arg_name in arg_mapping, expected)
 
     def test_calling_kill_subprocesses_will_break_out_of_command_execution_wait_loop(self):
+        self._mock_out_popen_communicate()
 
-        def fake_communicate(timeout=None):
-            # The fake implementation is that communicate() times out forever until os.killpg is called.
-            if mock_killpg.call_count == 0 and timeout is not None:
-                raise TimeoutExpired(None, timeout)
-            elif mock_killpg.call_count > 0:
-                return b'fake output', b'fake error'
-            self.fail('Popen.communicate() should not be called without a timeout before os.killpg has been called.')
-
-        mock_killpg = self.patch('os.killpg')
-        self.mock_popen.communicate.side_effect = fake_communicate
-        self.mock_popen.returncode = 1
-        self.mock_popen.pid = 55555
         project_type = ProjectType()
         command_thread = SafeThread(target=project_type.execute_command_in_project, args=('echo The power is yours!',))
 
@@ -112,25 +102,70 @@ class TestProjectType(BaseUnitTestCase):
         with UnhandledExceptionHandler.singleton():
             command_thread.join(timeout=10)
             if command_thread.is_alive():
-                mock_killpg()  # Calling killpg() causes the command thread to end.
+                self.mock_killpg()  # Calling killpg() causes the command thread to end.
                 self.fail('project_type.kill_subprocesses should cause the command execution wait loop to exit.')
 
-        mock_killpg.assert_called_once_with(pgid=55555, sig=ANY)
+        self.mock_killpg.assert_called_once_with(pgid=55555, sig=ANY)
 
     def test_command_exiting_normally_will_break_out_of_command_execution_wait_loop(self):
-        mock_killpg = self.patch('os.killpg')
-        timeout_exc = TimeoutExpired(None, 1)
-
         # Simulate Popen.communicate() timing out twice before command completes and returns output.
+        timeout_exc = TimeoutExpired(None, 1)
         self.mock_popen.communicate.side_effect = [timeout_exc, timeout_exc, (b'fake_output', b'fake_error')]
         self.mock_popen.returncode = 0
         self.mock_popen.pid = 55555
 
         project_type = ProjectType()
-        actual_return_output, actual_return_code = project_type.execute_command_in_project('echo The power is yours!')
+        actual_output, actual_return_code = project_type.execute_command_in_project('echo The power is yours!')
 
-        self.assertEqual(mock_killpg.call_count, 0, 'os.killpg should not be called when command exits normally.')
-        self.assertEqual(actual_return_output, 'fake_output\nfake_error', 'Output should contain stdout and stderr.')
+        self.assertEqual(self.mock_killpg.call_count, 0, 'os.killpg should not be called when command exits normally.')
+        self.assertEqual(actual_output, 'fake_output\nfake_error', 'Output should contain stdout and stderr.')
+
+    def test_timing_out_will_break_out_of_command_execution_wait_loop_and_kill_subprocesses(self):
+        mock_time = self.patch('time.time')
+        mock_time.side_effect = [0.0, 100.0, 200.0, 300.0]  # time increases by 100 seconds with each loop
+        self._mock_out_popen_communicate()
+        project_type = ProjectType()
+
+        actual_output, actual_return_code = project_type.execute_command_in_project(
+            command='sleep 99',
+            timeout=250,
+        )
+
+        self.assertEqual(self.mock_killpg.call_count, 1, 'os.killpg should be called when execution times out.')
+        self.assertEqual(actual_output, 'fake output\nfake error', 'Output should contain stdout and stderr.')
+
+    @genty_dataset(
+        with_specified_timeout=(30,),
+        with_no_timeout=(None,),
+    )
+    def test_teardown_build_executes_teardown_command(self, expected_timeout):
+        project_type = ProjectType()
+        mock_execute = MagicMock(return_value=('fake output', 0))
+        project_type.execute_command_in_project = mock_execute
+        project_type.job_config = MagicMock()
+
+        if expected_timeout:
+            project_type.teardown_build(timeout=expected_timeout)
+        else:
+            project_type.teardown_build()
+
+        mock_execute.assert_called_once_with(ANY, timeout=expected_timeout)
+
+    def _mock_out_popen_communicate(self):
+        """
+        Replace the Popen.communicate() call with a fake implementation.
+        """
+        def fake_communicate(timeout=None):
+            # The fake implementation is that communicate() times out forever until os.killpg is called.
+            if self.mock_killpg.call_count == 0 and timeout is not None:
+                raise TimeoutExpired(None, timeout)
+            elif self.mock_killpg.call_count > 0:
+                return b'fake output', b'fake error'
+            self.fail('Popen.communicate() should not be called without a timeout before os.killpg has been called.')
+
+        self.mock_popen.communicate.side_effect = fake_communicate
+        self.mock_popen.returncode = 1
+        self.mock_popen.pid = 55555
 
 
 class _FakeEnvWithoutDefaultArgs(ProjectType):

--- a/test/unit/slave/test_cluster_slave.py
+++ b/test/unit/slave/test_cluster_slave.py
@@ -45,20 +45,48 @@ class TestClusterSlave(BaseUnitTestCase):
     )
     def test_disconnect_request_sent_if_and_only_if_master_is_responsive(self, is_master_responsive):
         master_url = 'uncle.pennybags.gov:15139'
-        slave_connect_api_url = 'http://uncle.pennybags.gov:15139/v1/slave'
-        slave_disconnect_api_url = 'http://uncle.pennybags.gov:15139/v1/slave/1/disconnect'
+        connect_api_url = 'http://{}/v1/slave'.format(master_url)
+        disconnect_api_url = 'http://{}/v1/slave/1/disconnect'.format(master_url)
         if not is_master_responsive:
             self.mock_network.get.side_effect = requests.ConnectionError  # trigger an exception on get
 
         slave = ClusterSlave(port=15140, host='uncle.pennybags.gov')
         slave.connect_to_master(master_url)
-        slave._async_teardown_build(should_disconnect_from_master=True)
+        slave._send_master_disconnect_notification()
 
         # always expect a connect call, and if the master is responsive also expect a disconnect call
-        expected_network_post_calls = [call(slave_connect_api_url, ANY)]
+        expected_network_post_calls = [call(connect_api_url, ANY)]
         if is_master_responsive:
-            expected_network_post_calls.append(call(slave_disconnect_api_url))
+            expected_network_post_calls.append(call(disconnect_api_url))
 
         self.mock_network.post.assert_has_calls(expected_network_post_calls, any_order=True)
         self.assertEqual(self.mock_network.post.call_count, len(expected_network_post_calls),
                          'All POST requests should be accounted for in the test.')
+
+    def test_signal_shutdown_process_disconnects_from_master_before_killing_executors(self):
+        master_url = 'uncle.pennybags.gov:15139'
+        disconnect_api_url = 'http://{}/v1/slave/1/disconnect'.format(master_url)
+        mock_executor = self.patch('app.slave.cluster_slave.SubjobExecutor').return_value
+
+        parent_mock = MagicMock()  # create a parent mock so we can assert on the order of child mock calls.
+        parent_mock.attach_mock(self.mock_network, 'mock_network')
+        parent_mock.attach_mock(mock_executor, 'mock_executor')
+
+        slave = ClusterSlave(port=15140, host='thimble.pennybags.gov', num_executors=3)
+        slave.connect_to_master(master_url)
+        self.trigger_graceful_app_shutdown()
+
+        expected_disconnect_call = call.mock_network.post(disconnect_api_url)
+        expected_kill_executor_call = call.mock_executor.kill()
+        self.assertEqual(1, parent_mock.method_calls.count(expected_disconnect_call),
+                         'Graceful shutdown should cause the slave to make a disconnect call to the master.')
+        self.assertEqual(3, parent_mock.method_calls.count(expected_kill_executor_call),
+                         'Graceful shutdown should cause the slave to kill all its executors.')
+        self.assertLess(parent_mock.method_calls.index(expected_disconnect_call),
+                        parent_mock.method_calls.index(expected_kill_executor_call),
+                        'Graceful shutdown should disconnect from the master before killing its executors.')
+
+    def test_shutting_down_before_connecting_to_master_does_not_raise_exception(self):
+        ClusterSlave(port=15140, host='thimble.pennybags.gov')
+        self.trigger_graceful_app_shutdown()
+        # This test is successful if app shutdown does not raise a SystemExit exception.

--- a/test/unit/util/test_unhandled_exception_handler.py
+++ b/test/unit/util/test_unhandled_exception_handler.py
@@ -38,7 +38,7 @@ class TestUnhandledExceptionHandler(BaseUnitTestCase):
 
         self.assertEqual(an_evil_callback.call_count, 1, 'A teardown callback should be executed once.')
         callback_exception_was_logged = self.log_handler.has_error(
-            AnyStringMatching('Teardown callback .* raised exception.')
+            AnyStringMatching('Exception raised by teardown callback.*')
         )
         self.assertTrue(callback_exception_was_logged, 'Exception handler should log teardown callback exceptions.')
 


### PR DESCRIPTION
- Add timeout to teardown_build command execution when teardown is
  triggered by signal.
- Refactor the `ClusterSlave._async_teardown_build` method into a few
  separate methods.
- Give names to the async setup and async teardown threads so that we
  can distinguish them more easily in the logs.
- Don't register callback to disconnect from master until we've actually
  connected to the master. (This was causing an exception before.)
- Make sure to exit with a non-zero exit code if an exception is raised
  during execution of teardown handlers.
