### PR TITLE
Don't execute build teardown multiple times

### DIFF
--- a/test/framework/base_unit_test_case.py
+++ b/test/framework/base_unit_test_case.py
@@ -15,12 +15,13 @@ class BaseUnitTestCase(TestCase):
     _base_setup_called = False
     # This allows test classes (e.g., TestNetwork) to disable network-related patches for testing the patched code.
     _do_network_mocks = True
+    _repatchable_items = {}
 
     def setUp(self):
         super().setUp()
         self.addCleanup(patch.stopall)
 
-        self._repatchable_items = {}
+        self._repatchable_items = {}  # Reset this at the start of each test.
         self._blacklist_methods_not_allowed_in_unit_tests()
 
         # Stub out a few library dependencies that launch subprocesses.
@@ -136,7 +137,7 @@ class BaseUnitTestCase(TestCase):
         exception is raised in any of the teardown handlers.
         """
         with UnhandledExceptionHandler.singleton():
-            raise _TriggerGracefulShutdown
+            raise _GracefulShutdownTrigger
 
     def _blacklist_methods_not_allowed_in_unit_tests(self):
         """
@@ -186,7 +187,7 @@ class UnitTestPatchError(Exception):
     pass
 
 
-class _TriggerGracefulShutdown(BaseException):
+class _GracefulShutdownTrigger(BaseException):
     """
     This is a dummy exception used only for triggering the graceful shutdown (running teardown callbacks registered
     with UnhandledExceptionHandler) during a test. This inherits from BaseException to prevent UnhandledExceptionHandler

--- a/test/unit/master/test_build.py
+++ b/test/unit/master/test_build.py
@@ -5,8 +5,6 @@ from app.project_type.project_type import ProjectType
 from app.master.build import Build, BuildStatus
 from app.master.build_request import BuildRequest
 from app.master.job_config import JobConfig
-# TODO(dtran): Fix circular import issues that require lines like this to exist (ClusterMaster imports Slave imports ClusterMaster...)
-import app.master.cluster_master
 from app.master.slave import Slave
 from app.master.subjob import Subjob
 from app.util import poll

--- a/test/unit/master/test_slave.py
+++ b/test/unit/master/test_slave.py
@@ -1,0 +1,43 @@
+
+from app.master.slave import Slave
+from test.framework.base_unit_test_case import BaseUnitTestCase
+
+
+class TestSlave(BaseUnitTestCase):
+
+    _FAKE_SLAVE_URL = 'splinter.sensei.net:43001'
+    _FAKE_NUM_EXECUTORS = 10
+
+    def setUp(self):
+        super().setUp()
+        self.mock_network = self.patch('app.master.slave.Network').return_value
+
+    def test_disconnect_command_is_sent_during_teardown_when_slave_is_still_connected(self):
+        slave = self._create_slave()
+        slave.current_build_id = 3
+        slave.is_alive = True
+
+        slave.teardown()
+
+        expected_teardown_url = 'http://splinter.sensei.net:43001/v1/build/3/teardown'
+        self.mock_network.post.assert_called_once_with(expected_teardown_url)
+
+    def test_disconnect_command_is_not_sent_during_teardown_when_slave_has_disconnected(self):
+        slave = self._create_slave()
+        slave.current_build_id = 3
+        slave.is_alive = False
+
+        slave.teardown()
+
+        self.assertEqual(self.mock_network.post.call_count, 0,
+                         'Master should not send teardown command to slave when slave has disconnected.')
+
+    def _create_slave(self, **kwargs):
+        """
+        Create a slave for testing.
+        :param kwargs: Any constructor parameters for the slave; if none are specified, test defaults will be used.
+        :rtype: Slave
+        """
+        kwargs.setdefault('slave_url', self._FAKE_SLAVE_URL)
+        kwargs.setdefault('num_executors', self._FAKE_NUM_EXECUTORS)
+        return Slave(**kwargs)

--- a/test/unit/slave/test_cluster_slave.py
+++ b/test/unit/slave/test_cluster_slave.py
@@ -1,26 +1,35 @@
 from box.test.genty import genty, genty_dataset
+import http.client
 import requests
 import requests.models
-from unittest.mock import ANY, call, MagicMock
+from threading import Event
+from unittest.mock import ANY, call, MagicMock, mock_open
 
-from app.slave.cluster_slave import ClusterSlave
+from app.slave.cluster_slave import ClusterSlave, BuildTeardownError
 from app.util.exceptions import BadRequestError
+from app.util.safe_thread import SafeThread
+from app.util.unhandled_exception_handler import UnhandledExceptionHandler
 from test.framework.base_unit_test_case import BaseUnitTestCase
 
 
 @genty
 class TestClusterSlave(BaseUnitTestCase):
 
+    _FAKE_MASTER_URL = 'uncle.pennybags.gov:15139'
+    _FAKE_SLAVE_HOST = 'racecar.pennybags.gov'
+    _FAKE_SLAVE_PORT = 15140
+
     def setUp(self):
         super().setUp()
         self.mock_network = self.patch('app.slave.cluster_slave.Network').return_value
+        self.patch('app.util.fs.compress_directories')
 
     @genty_dataset(
         current_build_id_not_set=(None,),
         current_build_id_not_matching=(200,),
     )
     def test_start_working_on_subjob_called_with_incorrect_build_id_will_raise(self, slave_current_build_id):
-        slave = ClusterSlave(port=15140, host='uncle.pennybags.gov')
+        slave = self._create_cluster_slave()
         slave._current_build_id = slave_current_build_id
         incorrect_build_id = 300
 
@@ -32,7 +41,7 @@ class TestClusterSlave(BaseUnitTestCase):
         current_build_id_not_matching=(200,),
     )
     def test_teardown_called_with_incorrect_build_id_will_raise(self, slave_current_build_id):
-        slave = ClusterSlave(port=15140, host='uncle.pennybags.gov')
+        slave = self._create_cluster_slave()
         slave._current_build_id = slave_current_build_id
         incorrect_build_id = 300
 
@@ -44,14 +53,13 @@ class TestClusterSlave(BaseUnitTestCase):
         unresponsive_master=(False,),
     )
     def test_disconnect_request_sent_if_and_only_if_master_is_responsive(self, is_master_responsive):
-        master_url = 'uncle.pennybags.gov:15139'
-        connect_api_url = 'http://{}/v1/slave'.format(master_url)
-        disconnect_api_url = 'http://{}/v1/slave/1/disconnect'.format(master_url)
+        connect_api_url = 'http://{}/v1/slave'.format(self._FAKE_MASTER_URL)
+        disconnect_api_url = 'http://{}/v1/slave/1/disconnect'.format(self._FAKE_MASTER_URL)
         if not is_master_responsive:
             self.mock_network.get.side_effect = requests.ConnectionError  # trigger an exception on get
 
-        slave = ClusterSlave(port=15140, host='uncle.pennybags.gov')
-        slave.connect_to_master(master_url)
+        slave = self._create_cluster_slave()
+        slave.connect_to_master(self._FAKE_MASTER_URL)
         slave._send_master_disconnect_notification()
 
         # always expect a connect call, and if the master is responsive also expect a disconnect call
@@ -64,16 +72,15 @@ class TestClusterSlave(BaseUnitTestCase):
                          'All POST requests should be accounted for in the test.')
 
     def test_signal_shutdown_process_disconnects_from_master_before_killing_executors(self):
-        master_url = 'uncle.pennybags.gov:15139'
-        disconnect_api_url = 'http://{}/v1/slave/1/disconnect'.format(master_url)
+        disconnect_api_url = 'http://{}/v1/slave/1/disconnect'.format(self._FAKE_MASTER_URL)
         mock_executor = self.patch('app.slave.cluster_slave.SubjobExecutor').return_value
 
         parent_mock = MagicMock()  # create a parent mock so we can assert on the order of child mock calls.
         parent_mock.attach_mock(self.mock_network, 'mock_network')
         parent_mock.attach_mock(mock_executor, 'mock_executor')
 
-        slave = ClusterSlave(port=15140, host='thimble.pennybags.gov', num_executors=3)
-        slave.connect_to_master(master_url)
+        slave = self._create_cluster_slave(num_executors=3)
+        slave.connect_to_master(self._FAKE_MASTER_URL)
         self.trigger_graceful_app_shutdown()
 
         expected_disconnect_call = call.mock_network.post(disconnect_api_url)
@@ -87,6 +94,77 @@ class TestClusterSlave(BaseUnitTestCase):
                         'Graceful shutdown should disconnect from the master before killing its executors.')
 
     def test_shutting_down_before_connecting_to_master_does_not_raise_exception(self):
-        ClusterSlave(port=15140, host='thimble.pennybags.gov')
+        self._create_cluster_slave()
         self.trigger_graceful_app_shutdown()
         # This test is successful if app shutdown does not raise a SystemExit exception.
+
+    def test_shutting_down_after_running_a_build_does_not_raise_exception(self):
+        self.patch('app.slave.cluster_slave.util.create_project_type')
+        self.patch('app.slave.cluster_slave.open', new=mock_open(read_data=''), create=True)
+        slave = self._create_cluster_slave()
+        expected_results_api_url = 'http://{}/v1/build/123/subjob/321/result'.format(self._FAKE_MASTER_URL)
+        expected_idle_api_url = 'http://{}/v1/slave/1/idle'.format(self._FAKE_MASTER_URL)
+        subjob_done_event, teardown_done_event = self._mock_network_post(expected_results_api_url,
+                                                                         expected_idle_api_url)
+        slave.connect_to_master(self._FAKE_MASTER_URL)
+        slave.setup_build(build_id=123, project_type_params={'type': 'Fake'})
+        slave.start_working_on_subjob(build_id=123, subjob_id=321,
+                                      subjob_artifact_dir='', atomic_commands=[])
+        # The timeout for this wait() is arbitrary, but it should be generous so the test isn't flaky on slow machines.
+        self.assertTrue(subjob_done_event.wait(timeout=5), 'Subjob execution code under test should post to expected '
+                                                           'results url very quickly.')
+        slave.teardown_build(123)
+        self.assertTrue(teardown_done_event.wait(timeout=5), 'Teardown code under test should post to expected idle '
+                                                             'url very quickly.')
+        self.trigger_graceful_app_shutdown()  # Triggering shutdown should not raise an exception.
+
+    def _mock_network_post(self, expected_results_api_url, expected_idle_api_url):
+        # Since subjob execution and teardown is async, we use Events to tell our test when each thread has completed.
+        subjob_done_event = Event()
+        teardown_done_event = Event()
+
+        def fake_network_post(url, *args, **kwargs):
+            if url == expected_results_api_url:
+                subjob_done_event.set()  # Consider subjob finished once code posts to results url.
+            elif url == expected_idle_api_url:
+                teardown_done_event.set()
+            mock_response = MagicMock(spec=requests.models.Response, create=True)
+            mock_response.status_code = http.client.OK
+            return mock_response
+
+        self.mock_network.post = fake_network_post
+        return subjob_done_event, teardown_done_event
+
+    def test_executing_build_teardown_multiple_times_will_raise_exception(self):
+        self.mock_network.post().status_code = http.client.OK
+        slave = self._create_cluster_slave()
+        # We use an Event here to make teardown_build() block and reliably recreate the race condition in the test.
+        teardown_event = Event()
+        project_type_mock = self.patch('app.slave.cluster_slave.util.create_project_type').return_value
+        project_type_mock.teardown_build.side_effect = teardown_event.wait
+
+        slave.connect_to_master(self._FAKE_MASTER_URL)
+        slave.setup_build(build_id=123, project_type_params={'type': 'Fake'})
+        self.assertTrue(slave._setup_complete_event.wait(timeout=5), 'Job setup should complete very quickly.')
+
+        # Start the first thread that does build teardown. This thread will block on teardown_build().
+        first_thread = SafeThread(target=slave._do_build_teardown_and_reset)
+        first_thread.start()
+        # Call build teardown() again and it should raise an exception.
+        with self.assertRaises(BuildTeardownError):
+            slave._do_build_teardown_and_reset()
+
+        # Cleanup: unblock first thread and let it finish..
+        teardown_event.set()
+        with UnhandledExceptionHandler.singleton():
+            first_thread.join()
+
+    def _create_cluster_slave(self, **kwargs):
+        """
+        Create a ClusterSlave for testing.
+        :param kwargs: Any constructor parameters for the slave; if none are specified, test defaults will be used.
+        :rtype: ClusterSlave
+        """
+        kwargs.setdefault('host', self._FAKE_SLAVE_HOST)
+        kwargs.setdefault('port', self._FAKE_SLAVE_PORT)
+        return ClusterSlave(**kwargs)


### PR DESCRIPTION
This fixes a bug where, even after a slave disconnected from the
master, the master could send a teardown command to the slave. Since
the slave already runs build_teardown when it's shutting down, it was
possible for build_teardown to get run twice.

This change fixes the master so that it doesn't send a teardown command
when a slave has already disconnected. It also makes the slave raise an
exception if build_teardown gets executed more than once.
