### PR TITLE
Print ClusterRunner version at start of log files

### DIFF
--- a/app/util/conf/stop_config_loader.py
+++ b/app/util/conf/stop_config_loader.py
@@ -10,4 +10,4 @@ class StopConfigLoader(BaseConfigLoader):
         """
         super().configure_defaults(conf)
         conf.set('log_filename', 'clusterrunner_stop.log')
-        conf.set('log_level', 'DEBUG')
+        conf.set('log_level', 'INFO')


### PR DESCRIPTION
This is a small change that logs an application summary, including
version info, at the start of each logfile. This should be helpful
when trying to debug user issues using their logfiles.
