### PR TITLE
Log slave id instead of url in subjob triggered event log

### DIFF
--- a/app/master/slave.py
+++ b/app/master/slave.py
@@ -95,7 +95,7 @@ class Slave(object):
 
         subjob_executor_id = response.json().get('executor_id')
         analytics.record_event(analytics.MASTER_TRIGGERED_SUBJOB, executor_id=subjob_executor_id,
-                               build_id=subjob.build_id(), subjob_id=subjob.subjob_id(), slave_url=self.url)
+                               build_id=subjob.build_id(), subjob_id=subjob.subjob_id(), slave_id=self.id)
 
     def num_executors_in_use(self):
         return self._num_executors_in_use.value()

--- a/app/web_framework/cluster_base_handler.py
+++ b/app/web_framework/cluster_base_handler.py
@@ -45,7 +45,7 @@ class ClusterBaseHandler(tornado.web.RequestHandler):
         except ValueError as ex:
             raise BadRequestError('Invalid JSON in request body.') from ex
 
-    def get(self):
+    def get(self, *args, **kwargs):
         """
         Enable GET on all endpoints by default.  Subclasses can override this without calling super().get()
         """

--- a/test/framework/base_unit_test_case.py
+++ b/test/framework/base_unit_test_case.py
@@ -4,9 +4,12 @@ import logbook
 from unittest import TestCase
 from unittest.mock import MagicMock, NonCallableMock, patch
 
-from app.util import log
+from app.master.build import Build
+from app.master.slave import Slave
+from app.util import analytics, log
 from app.util.conf.configuration import Configuration
 from app.util.conf.master_config_loader import MasterConfigLoader
+from app.util.counter import Counter
 from app.util.unhandled_exception_handler import UnhandledExceptionHandler
 
 
@@ -45,6 +48,11 @@ class BaseUnitTestCase(TestCase):
         MasterConfigLoader().configure_defaults(Configuration.singleton())
         MasterConfigLoader().configure_postload(Configuration.singleton())
         self.patch('app.util.conf.master_config_loader.MasterConfigLoader.load_from_config_file')
+
+        # Reset counters
+        Slave._slave_id_counter = Counter()
+        Build._build_id_counter = Counter()
+        analytics._event_id_generator = Counter()
 
         # Configure logging to go to stdout. This makes debugging easier by allowing us to see logs for failed tests.
         log.configure_logging('DEBUG')


### PR DESCRIPTION
This will reduce the size of the event log since including the URL
in each event is redundant.
