### PR TITLE
If the url to the repo has a colon in it, remove it.

### DIFF
--- a/app/project_type/git.py
+++ b/app/project_type/git.py
@@ -55,7 +55,7 @@ class Git(ProjectType):
         repo_name = url_full_path_parts[-1].split('.')[0]
         url_folder_path_parts = url_full_path_parts[:-1]
         repo_directory = os.path.join(Configuration['repo_directory'], url_components.netloc, *url_folder_path_parts)
-        return os.path.join(repo_directory, repo_name)
+        return fs.remove_invalid_path_characters(os.path.join(repo_directory, repo_name))
 
     @staticmethod
     def get_timing_file_directory(url):
@@ -66,11 +66,12 @@ class Git(ProjectType):
         :rtype: str
         """
         url_components = urlparse(url)
-        return os.path.join(
+        timings_directory = os.path.join(
             Configuration['timings_directory'],
             url_components.netloc,
             url_components.path.strip('/')
         )
+        return fs.remove_invalid_path_characters(timings_directory)
 
     # pylint: disable=redefined-builtin
     # Disable "redefined-builtin" because renaming the "hash" parameter would be a breaking change.
@@ -107,7 +108,6 @@ class Git(ProjectType):
         self._branch = branch
         self._hash = hash
         self._shallow = shallow
-
         self._repo_directory = self.get_full_repo_directory(self._url)
         self._timing_file_directory = self.get_timing_file_directory(self._url)
 
@@ -128,7 +128,6 @@ class Git(ProjectType):
 
         os.symlink(actual_project_directory, build_project_directory)
         self.project_directory = build_project_directory
-
 
     def _setup_build(self):
         """

--- a/app/util/fs.py
+++ b/app/util/fs.py
@@ -93,3 +93,13 @@ def compress_directories(target_dirs_to_archive_paths, tarfile_path):
             target_dir = os.path.normpath(dir_path)
 
             tar.add(target_dir, arcname=archive_name)
+
+def remove_invalid_path_characters(path):
+    """
+    :param path: the path that may contain invalid characters
+    :type path: str
+    :return: the path with the invalid characters removed
+    :rtype: str
+    """
+    # For now, just replace colons.
+    return path.replace(':', '')

--- a/test/unit/project_type/test_git.py
+++ b/test/unit/project_type/test_git.py
@@ -148,3 +148,20 @@ class TestGit(BaseUnitTestCase):
         timings_path = Git.get_timing_file_directory(url)
 
         self.assertEqual(timings_path, '/home/cr_user/.clusterrunner/timing/scm.example.com/path/to/project')
+
+    def test_get_repo_directory_removes_colon_from_directory_if_exists(self):
+        Configuration['repo_directory'] = '/tmp/repos'
+        git = Git("some_remote_value", 'origin', 'ref/to/some/branch')
+
+        repo_directory = git.get_full_repo_directory('ssh://source_control.cr.com:1234/master')
+
+        self.assertEqual(repo_directory, '/tmp/repos/source_control.cr.com1234/master')
+
+    def test_get_timing_file_directory_removes_colon_from_directory_if_exists(self):
+        Configuration['timings_directory'] = '/tmp/timings'
+        git = Git("some_remote_value", 'origin', 'ref/to/some/branch')
+
+        repo_directory = git.get_timing_file_directory('ssh://source_control.cr.com:1234/master')
+
+        self.assertEqual(repo_directory, '/tmp/timings/source_control.cr.com1234/master')
+


### PR DESCRIPTION
- Also separate out constructor functionality into its own method in
  git.py
