### PR TITLE
Fix log rotation deadlock

### DIFF
--- a/app/util/conf/base_config_loader.py
+++ b/app/util/conf/base_config_loader.py
@@ -124,6 +124,7 @@ class BaseConfigLoader(object):
             'master_hostname',
             'master_port',
             'log_filename',
+            'max_log_file_size',
             'eventlog_filename',
             'git_strict_host_key_checking',
             'cors_allowed_origins_regex',

--- a/app/util/log.py
+++ b/app/util/log.py
@@ -6,6 +6,7 @@ import logging
 import os
 import sys
 from termcolor import colored
+import threading
 
 from app.util import autoversioning, fs
 from app.util.conf.configuration import Configuration
@@ -154,9 +155,15 @@ class _ColorizingStreamHandler(StreamHandler):
 
 class _ColorizingRotatingFileHandler(_ColorizingStreamHandler, RotatingFileHandler):
     """
-    This is a RotatingFileHandler that colorizes its log messages.
+    This is a RotatingFileHandler that colorizes its log messages. It also adds an application summary log message at
+    the beginning of each log file.
     """
     _logfile_count = 1
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # The superclass implementation uses a Lock, but we need an RLock so that we can log a message during rollover.
+        self.lock = threading.RLock()
 
     def perform_rollover(self, increment_logfile_counter=True):
         """


### PR DESCRIPTION
There was a bug in log rotation added in #38. This issue would cause
the app to freeze up completely when it tried to rotate the first log
file. (Since the default log size is 50mb, we didn't hit this for
several days.)

The cause of the freeze was a deadlock in the log handler. Since we
added a new log statement (logging the app summary) during log
rotation, we now have a recursive logger call that tries to reacquire
a lock in the recursive call.

The simplest fix was to change the log handler lock from a Lock to an
RLock (reentrant lock). This allows the lock to be reacquired by the
same thread, and will prevent the recursive call from deadlocking.
