### PR TITLE
Remove dashes from repo names

### DIFF
--- a/app/util/fs.py
+++ b/app/util/fs.py
@@ -101,5 +101,5 @@ def remove_invalid_path_characters(path):
     :return: the path with the invalid characters removed
     :rtype: str
     """
-    # For now, just replace colons.
-    return path.replace(':', '')
+    # Replace colons and dashes
+    return path.replace(':', '').replace('-', '')


### PR DESCRIPTION
- The PHP Intl extension doesn't appear to work if the
  repo is in a directory with a dash in the path.
