### PR TITLE
Master waits on slave setup completion

### DIFF
--- a/app/master/slave.py
+++ b/app/master/slave.py
@@ -33,7 +33,7 @@ class Slave(object):
             'id': self.id,
             'num_executors': self.num_executors,
             'num_executors_in_use': self.num_executors_in_use(),
-            'current_build_id': self.current_build(),
+            'current_build_id': self.current_build_id,
         }
 
     def mark_as_idle(self):
@@ -63,6 +63,7 @@ class Slave(object):
             'project_type_params': slave_project_type_params,
         }
         self._network.post_with_digest(setup_url, post_data, Secret.get())
+        self.current_build_id = build_id
 
     def teardown(self):
         """
@@ -82,7 +83,6 @@ class Slave(object):
             raise RuntimeError('Tried to start a subjob on a dead slave! ({}, id: {})'.format(self.url, self.id))
 
         SafeThread(target=self._async_start_subjob, args=(subjob,)).start()
-        self.current_build_id = subjob.build_id()
 
     def _async_start_subjob(self, subjob):
         """
@@ -113,10 +113,3 @@ class Slave(object):
         if new_count < 0:
             raise Exception('Cannot free executor on slave {}. All are free.'.format(self.url))
         return new_count
-
-    def current_build(self):
-        """
-        :return:
-        :rtype: int|None
-        """
-        return self.current_build_id

--- a/app/project_type/project_type.py
+++ b/app/project_type/project_type.py
@@ -120,15 +120,15 @@ class ProjectType(object):
 
     def run_job_config_setup(self):
         """
-        Execute any setup commands defined in the job config
+        Execute any setup commands defined in the job config.
         """
         job_config = self.job_config()
         if job_config.setup_build:
             output, exit_code = self.execute_command_in_project(job_config.setup_build)
             if exit_code != 0:
-                raise RuntimeError('Job setup failed, cmd: {} -- output: {}'.format(job_config.setup_build,
-                                                                                    output))
-            self._logger.info('Job setup complete')
+                raise SetupFailureError('Build setup failed!\nCommand:\n"{}"\n\nOutput:\n{}'
+                                        .format(job_config.setup_build, output))
+            self._logger.info('Build setup completed successfully.')
 
     def run_job_config_teardown(self, timeout=None):
         """
@@ -141,9 +141,9 @@ class ProjectType(object):
         if job_config.teardown_build:
             output, exit_code = self.execute_command_in_project(job_config.teardown_build, timeout=timeout)
             if exit_code != 0:
-                raise RuntimeError('Job teardown failed, cmd: {} -- output: {}'.format(job_config.teardown_build,
-                                                                                       output))
-            self._logger.info('Job teardown complete')
+                raise TeardownFailureError('Build teardown failed!\nCommand:\n"{}"\n\nOutput:\n{}'
+                                           .format(job_config.teardown_build, output))
+            self._logger.info('Build teardown completed successfully.')
 
     def _setup_executors(self, executors, project_type_params):
         """
@@ -384,3 +384,11 @@ class ProjectType(object):
 
 
 _ProjectTypeArgumentInfo = namedtuple('_ProjectTypeArgumentInfo', ['help', 'required', 'default'])
+
+
+class SetupFailureError(Exception):
+    pass
+
+
+class TeardownFailureError(Exception):
+    pass

--- a/app/slave/cluster_slave.py
+++ b/app/slave/cluster_slave.py
@@ -1,9 +1,9 @@
-import http.client
+from enum import Enum
 from queue import Queue
-import sys
-from threading import Event
 import requests
+import sys
 
+from app.project_type.project_type import SetupFailureError
 from app.slave.subjob_executor import SubjobExecutor
 from app.util import analytics, log, util
 from app.util.exceptions import BadRequestError
@@ -41,7 +41,6 @@ class ClusterSlave(object):
             self._idle_executors.put(executor)
             self.executors_by_id[executor_id] = executor
 
-        self._setup_complete_event = Event()
         self._master_url = None
         self._network = Network(min_connection_poolsize=num_executors)
         self._master_api = None  # wait until we connect to a master first
@@ -55,11 +54,12 @@ class ClusterSlave(object):
         Gets a dict representing this resource which can be returned in an API response.
         :rtype: dict [str, mixed]
         """
+        # todo: add this to the ClusterSlave api response
         executors_representation = [executor.api_representation() for executor in self.executors_by_id.values()]
         return {
             'connected': str(self._is_connected()),
             'master_url': self._master_url,
-            'setup_complete': str(self._setup_complete_event.isSet()),
+            'current_build_id': self._current_build_id,
             'slave_id': self._slave_id,
             'executors': executors_representation,
         }
@@ -85,7 +85,6 @@ class ClusterSlave(object):
         :type project_type_params: dict
         """
         self._logger.info('Executing setup for build {} (type: {}).', build_id, project_type_params.get('type'))
-        self._setup_complete_event.clear()
         self._current_build_id = build_id
         self._build_teardown_coin = SingleUseCoin()  # protects against build_teardown being executed multiple times
 
@@ -110,13 +109,23 @@ class ClusterSlave(object):
         """
         Called from setup_build(). Do asynchronous setup for the build so that we can make the call to setup_build()
         non-blocking.
+
+        :type executors: list[SubjobExecutor]
+        :type project_type_params: dict
         """
         # todo(joey): It's strange that the project_type is setting up the executors, which in turn set up projects.
         # todo(joey): I think this can be untangled a bit -- we should call executor.configure_project_type() here.
-        self._project_type.setup_build(executors, project_type_params)
+        try:
+            self._project_type.setup_build(executors, project_type_params)
 
-        self._logger.info('Build setup complete for build {}.', self._current_build_id)
-        self._setup_complete_event.set()  # free any subjob threads that are waiting for setup to complete
+        except SetupFailureError as ex:
+            self._logger.error(ex)
+            self._logger.info('Notifying master that build setup has failed for build {}.', self._current_build_id)
+            self._notify_master_of_state_change(SlaveState.SETUP_FAILED)
+
+        else:
+            self._logger.info('Notifying master that build setup is complete for build {}.', self._current_build_id)
+            self._notify_master_of_state_change(SlaveState.SETUP_COMPLETED)
 
     def teardown_build(self, build_id=None):
         """
@@ -176,26 +185,18 @@ class ClusterSlave(object):
             self._logger.notice('Could not post idle notification to master because master is unresponsive.')
             return
 
-        # Report back to master that this slave is finished with teardown and ready for a new build
+        # Notify master that this slave is finished with teardown and ready for a new build.
         self._logger.info('Notifying master that this slave is ready for new builds.')
-        idle_url = self._master_api.url('slave', self._slave_id, 'idle')
-        response = self._network.post(idle_url)
-        if response.status_code != http.client.OK:
-            raise RuntimeError('Error during post of idle notification to master <{}>. (Response code: {})'
-                               .format(idle_url, response.status_code))
+        self._notify_master_of_state_change(SlaveState.IDLE)
 
     def _send_master_disconnect_notification(self):
         if not self._is_master_responsive():
             self._logger.notice('Could not post disconnect notification to master because master is unresponsive.')
             return
 
-        # Report back to master that this slave is shutting down and should not receive new builds
-        self._logger.info('Notifying master to disconnect this slave.')
-        disconnect_url = self._master_api.url('slave', self._slave_id, 'disconnect')
-        response = self._network.post(disconnect_url)
-        if response.status_code != http.client.OK:
-            self._logger.error('Disconnect notification to master <{}> failed with response code '
-                               '{}.'.format(disconnect_url, response.status_code))
+        # Notify master that this slave is shutting down and should not receive new builds.
+        self._logger.info('Notifying master that this slave is disconnecting.')
+        self._notify_master_of_state_change(SlaveState.DISCONNECTED)
 
     def connect_to_master(self, master_url=None):
         """
@@ -211,7 +212,7 @@ class ClusterSlave(object):
             'slave': '{}:{}'.format(self.host, self.port),
             'num_executors': self._num_executors,
         }
-        response = self._network.post(connect_url, data)
+        response = self._network.post(connect_url, data=data)
         self._slave_id = int(response.json().get('slave_id'))
         self._logger.info('Slave {}:{} connected to master on {}.', self.host, self.port, self._master_url)
 
@@ -279,8 +280,6 @@ class ClusterSlave(object):
         :type subjob_artifact_dir: str
         :type atomic_commands: list[str]
         """
-        self._logger.debug('Waiting for setup to complete (Build {}, Subjob {})...', build_id, subjob_id)
-        self._setup_complete_event.wait()  # block until setup completes
         subjob_event_data = {'build_id': build_id, 'subjob_id': subjob_id, 'executor_id': executor.id}
 
         analytics.record_event(analytics.SUBJOB_EXECUTION_START, **subjob_event_data)
@@ -299,9 +298,30 @@ class ClusterSlave(object):
 
         self._logger.info('Build {}, Subjob {} completed and sent results to master.', build_id, subjob_id)
 
+    def _notify_master_of_state_change(self, new_state):
+        """
+        Send a state notification to the master. This is used to notify the master of events occurring on the slave
+        related to build execution progress.
+
+        :type new_state: SlaveState
+        """
+        state_url = self._master_api.url('slave', self._slave_id)
+        self._network.put(state_url, data={'slave': {'state': new_state}}, error_on_failure=True)
+
     def kill(self):
         # TODO(dtran): Kill the threads and this server more gracefully
         sys.exit(0)
+
+
+class SlaveState(str, Enum):
+    """
+    An enum of possible slave states. Also inherits from string to allow comparisons with other strings (which is
+    useful when including these values in API responses).
+    """
+    DISCONNECTED = 'DISCONNECTED'
+    IDLE = 'IDLE'
+    SETUP_COMPLETED = 'SETUP_COMPLETE'
+    SETUP_FAILED = 'SETUP_FAILED'
 
 
 class BuildTeardownError(Exception):

--- a/app/util/network.py
+++ b/app/util/network.py
@@ -61,6 +61,27 @@ class Network(object):
         return self.post(url, encoded_body, headers=Secret.header(encoded_body, secret),
                          error_on_failure=error_on_failure)
 
+    def put(self, *args, **kwargs):
+        """
+        Send a PUT request to a url. Arguments to this method, unless otherwise documented below in _request(), are
+        exactly the same as arguments to session.put() in the requests library.
+
+        :rtype: requests.Response
+        """
+        return self._request('PUT', *args, **kwargs)
+
+    def put_with_digest(self, url, request_params, secret, error_on_failure=False):
+        """
+        Put to a url with the Message Authentication Digest
+        :type url: str
+        :type request_params: dict [str, str]
+        :param secret: the secret used to produce the message auth digest
+        :rtype: requests.Response
+        """
+        encoded_body = self.encode_body(request_params)
+        return self.put(url, encoded_body, headers=Secret.header(encoded_body, secret),
+                        error_on_failure=error_on_failure)
+
     def encode_body(self, body_decoded):
         """
         :type body_decoded: dict [str, str]

--- a/app/web_framework/cluster_master_application.py
+++ b/app/web_framework/cluster_master_application.py
@@ -41,10 +41,7 @@ class ClusterMasterApplication(ClusterApplication):
                     ]),
                     RouteNode(r'queue', _QueueHandler),
                     RouteNode(r'slave', _SlavesHandler, 'slaves').add_children([
-                        RouteNode(r'(\d+)', _SlaveHandler, 'slave').add_children([
-                            RouteNode(r'idle', _SlaveIdleHandler),
-                            RouteNode(r'disconnect', _SlaveDisconnectHandler)
-                        ])
+                        RouteNode(r'(\d+)', _SlaveHandler, 'slave')
                     ]),
                     RouteNode(r'eventlog', _EventlogHandler)
                 ])
@@ -226,18 +223,14 @@ class _SlaveHandler(_ClusterMasterBaseHandler):
         }
         self.write(response)
 
-
-class _SlaveIdleHandler(_ClusterMasterBaseHandler):
-    def post(self, slave_id):
+    def put(self, slave_id):
+        new_slave_state = self.decoded_body.get('slave', {}).get('state')
         slave = self._cluster_master.get_slave(int(slave_id))
-        self._cluster_master.add_idle_slave(slave)
-        self._write_status()
+        self._cluster_master.handle_slave_state_update(slave, new_slave_state)
 
-
-class _SlaveDisconnectHandler(_ClusterMasterBaseHandler):
-    def post(self, slave_id):
-        self._cluster_master.disconnect_slave(int(slave_id))
-        self._write_status()
+        self._write_status({
+            'slave': slave.api_representation()
+        })
 
 
 class _EventlogHandler(_ClusterMasterBaseHandler):

--- a/test/unit/master/test_build.py
+++ b/test/unit/master/test_build.py
@@ -1,12 +1,13 @@
 from queue import Queue
 from unittest.mock import MagicMock
 
-from app.project_type.project_type import ProjectType
+from app.master.atomizer import Atomizer
 from app.master.build import Build, BuildStatus
 from app.master.build_request import BuildRequest
 from app.master.job_config import JobConfig
 from app.master.slave import Slave
 from app.master.subjob import Subjob
+from app.project_type.project_type import ProjectType
 from app.util import poll
 from test.framework.base_unit_test_case import BaseUnitTestCase
 
@@ -36,24 +37,29 @@ class TestBuild(BaseUnitTestCase):
         # assert
         mock_slave.setup.assert_called_once_with(build.build_id(), project_type_params={'setup': fake_setup_command})
 
-    def test_allocate_slave_doesnt_use_more_than_max_executors(self):
+    def test_slave_doesnt_use_more_than_max_executors(self):
         subjobs = self._create_subjobs()
-
         mock_project_type = self._create_mock_project_type()
         fake_setup_command = 'mock command'
-        mock_slave = self._create_mock_slave()
+        mock_slaves = [self._create_mock_slave(num_executors=5) for _ in range(3)]
+        expected_num_max_executors = 12  # We expect the slave to use 12 out of 15 available executors.
 
         build = Build(BuildRequest({'setup': fake_setup_command}))
-        build.prepare(subjobs, mock_project_type, self._create_job_config(1))
-        build.allocate_slave(mock_slave)
+        build.execute_next_subjob_on_slave = MagicMock()
 
-        self.assertEqual(build._num_allocated_executors, build._max_executors)
+        build.prepare(subjobs, mock_project_type, self._create_job_config(max_executors=expected_num_max_executors))
+        [build.allocate_slave(mock_slave) for mock_slave in mock_slaves]
+        [build.begin_subjob_executions_on_slave(mock_slave) for mock_slave in mock_slaves]
+
+        self.assertEqual(build.execute_next_subjob_on_slave.call_count, expected_num_max_executors,
+                         'Build should start executing as many subjobs as its max_executors setting.')
 
     def test_build_status_returns_requested_after_build_creation(self):
         build = Build(BuildRequest({}))
         status = build._status()
 
-        self.assertEqual(status, BuildStatus.QUEUED)
+        self.assertEqual(status, BuildStatus.QUEUED,
+                         'Build status should be QUEUED immediately after build has been created.')
 
     def test_build_status_returns_queued_after_build_preparation(self):
         subjobs = self._create_subjobs()
@@ -63,19 +69,33 @@ class TestBuild(BaseUnitTestCase):
         build.prepare(subjobs, mock_project_type, self._create_job_config(self._FAKE_MAX_EXECUTORS))
         status = build._status()
 
-        self.assertEqual(status, BuildStatus.QUEUED)
+        self.assertEqual(status, BuildStatus.QUEUED,
+                         'Build status should be QUEUED after build has been prepared.')
 
-    def test_build_status_returns_building_after_some_subjobs_are_executing(self):
+    def test_build_status_returns_building_after_setup_has_started(self):
+        subjobs = self._create_subjobs()
+        mock_project_type = self._create_mock_project_type()
+        mock_slave = self._create_mock_slave()
+        build = Build(BuildRequest({}))
+
+        build.prepare(subjobs, mock_project_type, self._create_job_config(self._FAKE_MAX_EXECUTORS))
+        build.allocate_slave(mock_slave)
+
+        self.assertEqual(build._status(), BuildStatus.BUILDING,
+                         'Build status should be BUILDING after setup has started on slaves.')
+
+    def test_build_status_returns_building_after_setup_is_complete_and_subjobs_are_executing(self):
         subjobs = self._create_subjobs(count=3)
         mock_project_type = self._create_mock_project_type()
         mock_slave = self._create_mock_slave(num_executors=2)
         build = Build(BuildRequest({}))
 
         build.prepare(subjobs, mock_project_type, self._create_job_config(self._FAKE_MAX_EXECUTORS))
-        build.allocate_slave(mock_slave)  # two out of three subjobs are now "in progress"
-        status = build._status()
+        build.allocate_slave(mock_slave)
+        build.begin_subjob_executions_on_slave(mock_slave)  # two out of three subjobs are now in progress
 
-        self.assertEqual(status, BuildStatus.BUILDING)
+        self.assertEqual(build._status(), BuildStatus.BUILDING,
+                         'Build status should be BUILDING after subjobs have started executing on slaves.')
 
     def test_build_status_returns_finished_after_all_subjobs_complete_and_slaves_finished(self):
         subjobs = self._create_subjobs(count=3)
@@ -156,7 +176,8 @@ class TestBuild(BaseUnitTestCase):
         return [Subjob(build_id=0, subjob_id=i, project_type=None, job_config=None, atoms=[]) for i in range(count)]
 
     def _create_job_config(self, max_executors):
-        return JobConfig('', '', '', '', '', max_executors)
+        atomizer = Atomizer([{'FAKE': 'fake atomizer command'}])
+        return JobConfig('', '', '', '', atomizer, max_executors)
 
     def _create_mock_project_type(self):
         return MagicMock(spec_set=ProjectType())

--- a/test/unit/master/test_cluster_master.py
+++ b/test/unit/master/test_cluster_master.py
@@ -5,7 +5,8 @@ from app.master.build import Build
 from app.master.build_request import BuildRequest
 from app.master.cluster_master import ClusterMaster
 from app.master.slave import Slave
-from app.util.exceptions import ItemNotFoundError
+from app.slave.cluster_slave import SlaveState
+from app.util.exceptions import BadRequestError, ItemNotFoundError
 from test.framework.base_unit_test_case import BaseUnitTestCase
 
 
@@ -17,7 +18,7 @@ class TestClusterMaster(BaseUnitTestCase):
         self.patch('app.util.fs.create_dir')
         self.patch('shutil.rmtree')
 
-    def test_add_idle_slave_marks_build_finished_when_slaves_are_done(self):
+    def test_updating_slave_to_idle_state_marks_build_finished_when_slaves_are_done(self):
         master = ClusterMaster()
         slave1 = Slave('', 1)
         slave2 = Slave('', 1)
@@ -30,10 +31,10 @@ class TestClusterMaster(BaseUnitTestCase):
         master._all_builds_by_id = {1: build1}
         build1._build_id = 1
         build1.finish = MagicMock()
-        master.add_idle_slave(slave1)
+        master.handle_slave_state_update(slave1, SlaveState.IDLE)
         build1.finish.assert_called_once_with()
 
-    def test_add_idle_slave_does_not_mark_build_finished_when_slaves_not_done(self):
+    def test_updating_slave_to_idle_state_does_not_mark_build_finished_when_slaves_not_done(self):
         master = ClusterMaster()
         slave1 = Slave('', 1)
         slave2 = Slave('', 1)
@@ -46,7 +47,7 @@ class TestClusterMaster(BaseUnitTestCase):
         master._all_builds_by_id = {1: build1}
         build1._build_id = 1
         build1.finish = MagicMock()
-        master.add_idle_slave(slave1)
+        master.handle_slave_state_update(slave1, SlaveState.IDLE)
         self.assertFalse(build1.finish.called)
 
     @genty_dataset(
@@ -85,3 +86,35 @@ class TestClusterMaster(BaseUnitTestCase):
         self.assertEqual(2, actual_slave_by_id.id, 'Retrieved slave should have the same id as requested.')
         self.assertEqual('leonardo.turtles.gov', actual_slave_by_url.url,
                          'Retrieved slave should have the same url as requested.')
+
+    def test_updating_slave_to_disconnected_state_should_mark_slave_as_dead(self):
+        master = ClusterMaster()
+        slave_url = 'raphael.turtles.gov'
+        master.connect_new_slave(slave_url, 10)
+        slave = master.get_slave(slave_url=slave_url)
+        self.assertTrue(slave.is_alive)
+
+        master.handle_slave_state_update(slave, SlaveState.DISCONNECTED)
+
+        self.assertFalse(slave.is_alive)
+
+    def test_updating_slave_to_setup_completed_state_should_tell_build_to_begin_subjob_execution(self):
+        master = ClusterMaster()
+        fake_build = MagicMock()
+        master.get_build = MagicMock(return_value=fake_build)
+        slave_url = 'raphael.turtles.gov'
+        master.connect_new_slave(slave_url, 10)
+        slave = master.get_slave(slave_url=slave_url)
+
+        master.handle_slave_state_update(slave, SlaveState.SETUP_COMPLETED)
+
+        fake_build.begin_subjob_executions_on_slave.assert_called_once_with(slave)
+
+    def test_updating_slave_to_nonexistent_state_should_raise_bad_request_error(self):
+        master = ClusterMaster()
+        slave_url = 'raphael.turtles.gov'
+        master.connect_new_slave(slave_url, 10)
+        slave = master.get_slave(slave_url=slave_url)
+
+        with self.assertRaises(BadRequestError):
+            master.handle_slave_state_update(slave, 'NONEXISTENT_STATE')


### PR DESCRIPTION
The master no longer sends subjobs immediately after triggering build
setup on the slave. The slave now executes build setup, then notifies
the master of whether setup was successful or not. If successful, then
the master starts sending subjobs to the slave.

If setup failed, currently the master will tell the slave to shut down
but we'll change this in a future commit to just reset the slave.

As part of this change, I also refactored how the slave sends "idle"
and "disconnect" notifications to the master. Previously "idle" and
"disconnect" were their own API endpoints. Now the slave does a PUT
on a slave state field. This, besides being more "restful", is more
extensible if we want to add more state notifications in the future.

This change fixes a bug where if build setup failed on the slave, the
slave would shut down completely. (This is actually still the behavior,
but now it is more explicit and we can easily change the behavior in a
future commit.)
