### PR TITLE
Implement max_executors_per_slave job conf setting

### DIFF
--- a/app/master/cluster_runner_config.py
+++ b/app/master/cluster_runner_config.py
@@ -12,6 +12,7 @@ TEARDOWN_BUILD = 'teardown_build'
 COMMANDS = 'commands'
 ATOMIZERS = 'atomizers'
 MAX_EXECUTORS = 'max_executors'
+MAX_EXECUTORS_PER_SLAVE = 'max_executors_per_slave'
 
 
 class ClusterRunnerConfig(object):
@@ -81,6 +82,7 @@ class ClusterRunnerConfig(object):
             COMMANDS: [(list, str)],
             ATOMIZERS: [(list, dict)],  # (list, dict) means this field should be a list of dicts
             MAX_EXECUTORS: [int],
+            MAX_EXECUTORS_PER_SLAVE: [int],
         }
 
         for job_name, job_config_sections in config.items():
@@ -139,8 +141,10 @@ class ClusterRunnerConfig(object):
 
         atomizer = Atomizer(job_values[ATOMIZERS])
         max_executors = job_values.get(MAX_EXECUTORS, self.DEFAULT_MAX_EXECUTORS)
+        max_executors_per_slave = job_values.get(MAX_EXECUTORS_PER_SLAVE, self.DEFAULT_MAX_EXECUTORS)
 
-        return JobConfig(job_name, setup_build, teardown_build, command, atomizer, max_executors)
+        return JobConfig(job_name, setup_build, teardown_build, command, atomizer, max_executors,
+                         max_executors_per_slave)
 
     def _shell_command_list_to_single_command(self, commands):
         """

--- a/app/master/job_config.py
+++ b/app/master/job_config.py
@@ -1,7 +1,7 @@
 
 
 class JobConfig(object):
-    def __init__(self, name, setup_build, teardown_build, command, atomizer, max_executors):
+    def __init__(self, name, setup_build, teardown_build, command, atomizer, max_executors, max_executors_per_slave):
         """
         :type name: str
         :type setup_build: str | None
@@ -9,6 +9,7 @@ class JobConfig(object):
         :type command: str
         :type atomizer: Atomizer
         :type max_executors: int | None
+        :type max_executors_per_slave: int | None
         """
         self.name = name
         self.setup_build = setup_build
@@ -16,3 +17,4 @@ class JobConfig(object):
         self.command = command
         self.atomizer = atomizer
         self.max_executors = max_executors
+        self.max_executors_per_slave = max_executors_per_slave

--- a/examples/directory job/clusterrunner.yaml
+++ b/examples/directory job/clusterrunner.yaml
@@ -1,4 +1,6 @@
 SampleJob:
+    max_executors: 2
+    max_executors_per_slave: 5
     setup_build:
         - echo "run setup"
     commands:

--- a/test/unit/project_type/test_project_type.py
+++ b/test/unit/project_type/test_project_type.py
@@ -52,7 +52,7 @@ class TestProjectType(BaseUnitTestCase):
                          'Actual default value for argument should match expected.')
 
     def test_teardown_build_runs_teardown(self):
-        job_config = JobConfig('name', 'setup', 'teardown', 'command', 'atomizer', 10)
+        job_config = JobConfig('name', 'setup', 'teardown', 'command', 'atomizer', 10, 10)
         project_type = ProjectType()
         project_type.job_config = MagicMock(return_value=job_config)
         project_type.execute_command_in_project = MagicMock(return_value=('', 0))


### PR DESCRIPTION
We currently allow users to specify a "max_executors" setting on their
jobs. This is useful to prevent one job from "overparallelizing" and
monopolizing an entire cluster.

This change implements an additional job config setting called
"max_executors_per_slave". This is useful, for example, on jobs which
*can* be parallelized across multiple machines, but *cannot* be
parallelized with multiple processes on a single machine. (That problem
can now be solved by setting max_executors_per_slave to 1.)