### PR TITLE
Update slave allocation increment value

### DIFF
--- a/app/master/build.py
+++ b/app/master/build.py
@@ -119,7 +119,8 @@ class Build(object):
         :type slave: Slave
         """
         self._slaves_allocated.append(slave)
-        self._num_executors_allocated += slave.num_executors
+        self._num_executors_allocated += min(slave.num_executors, self._max_executors_per_slave)
+
         slave.setup(self.build_id(), project_type_params=self.build_request.build_parameters())
 
     def all_subjobs(self):

--- a/test/unit/master/test_build.py
+++ b/test/unit/master/test_build.py
@@ -276,6 +276,21 @@ class TestBuild(BaseUnitTestCase):
 
         self.assertEqual(slave.teardown.call_count, 1, "Teardown should only be called once")
 
+    def test_allocate_slave_increments_by_num_executors_when_max_is_inf(self):
+        build = Build(BuildRequest({}))
+        slave = Mock()
+        slave.num_executors = 10
+        build.allocate_slave(slave)
+        self.assertEqual(build._num_executors_allocated, 10, "Should be incremented by num executors")
+
+    def test_allocate_slave_increments_by_per_slave_when_max_not_inf_and_less_than_num(self):
+        build = Build(BuildRequest({}))
+        build._max_executors_per_slave = 5
+        slave = Mock()
+        slave.num_executors = 10
+        build.allocate_slave(slave)
+        self.assertEqual(build._num_executors_allocated, 5, "Should be incremented by num executors")
+
     def _create_subjobs(self, count=3):
         return [Subjob(build_id=0, subjob_id=i, project_type=None, job_config=None, atoms=[]) for i in range(count)]
 


### PR DESCRIPTION
Number of executors for a build was being incremented by
the number of executors on a slave during allocation.

If the max executors per slave, is set to a value
significantly less than the number of executors on the slave,
a build could end up with far fewer allocated slaves then expected.

This commit makes it so that the number of executors on the build
is incrmented by max executors per slave if it is less than the
number of executors available on the slave.