### PR TITLE
Prevent clusterrunner zombie processes

### DIFF
--- a/test/framework/comparators.py
+++ b/test/framework/comparators.py
@@ -3,7 +3,7 @@ import re
 
 class AnyStringMatching(object):
     """
-    A helper object that compares equal to any string matching the specified pattern."
+    A helper object that compares equal to any string matching the specified pattern.
     """
     def __init__(self, pattern):
         self._pattern = pattern
@@ -14,3 +14,17 @@ class AnyStringMatching(object):
 
     def __repr__(self):
         return '<any string matching "{}">'.format(self._pattern)
+
+
+class AnythingOfType(object):
+    """
+    A helper object that compares equal to any object of the specified type.
+    """
+    def __init__(self, accepted_type):
+        self._type = accepted_type
+
+    def __eq__(self, other):
+        return isinstance(other, self._type)
+
+    def __repr__(self):
+        return '<any object of type {}>'.format(self._type)


### PR DESCRIPTION
This change adds a method to the main thread that will start a timer
of 10 seconds right before the main thread finishes. After 10 seconds,
the application will dump some debug info to the logs and then send
itself a SIGKILL signal.

The dumped debug info includes the stack traces of all currently
running threads.

This is to address an issue where we see the application shutdown the
web server but the process continues to run. This does not affect
deployment of newer versions but just causes us to have some old
zombie clusterrunner processes that we have to kill manually. This
change should prevent those zombies.