### PR TITLE
'clusterrunner deploy' times out on deleting build results

### DIFF
--- a/app/master/cluster_master.py
+++ b/app/master/cluster_master.py
@@ -47,10 +47,10 @@ class ClusterMaster(object):
         # It's important that idle slaves are only in the queue once so we use OrderedSet
         self._idle_slaves = OrderedSetQueue()
 
-        # Delete all old builds when master starts.  Remove this if/when build numbers are unique across master
-        # starts/stops
+        # Asynchronously delete (but immediately rename) all old builds when master starts.
+        # Remove this if/when build numbers are unique across master starts/stops
         if os.path.exists(self._master_results_path):
-            shutil.rmtree(self._master_results_path)
+            fs.async_delete(self._master_results_path)
 
         fs.create_dir(self._master_results_path)
 

--- a/app/master/cluster_master.py
+++ b/app/master/cluster_master.py
@@ -1,7 +1,6 @@
 from collections import OrderedDict
 import os
 from queue import Queue
-import shutil
 
 from app.master.build import Build
 from app.master.build_request import BuildRequest

--- a/app/util/fs.py
+++ b/app/util/fs.py
@@ -23,7 +23,7 @@ def async_delete(path):
         _, new_temp_path = tempfile.mkstemp(prefix='async_delete_file')
 
     shutil.move(path, new_temp_path)
-    subprocess.Popen("rm -rf {}".format(new_temp_path), shell=True)
+    subprocess.Popen(['rm', '-rf', new_temp_path])
 
 def create_dir(dir_path, mode=None):
     """

--- a/app/util/fs.py
+++ b/app/util/fs.py
@@ -1,6 +1,29 @@
 import os
+import shutil
 import tarfile
+import tempfile
+import subprocess
 
+def async_delete(path):
+    """
+    Asynchronously delete a file or a directory. This functionality is handy for deleting large directories.
+    For example, in ClusterRunner, deleting the results directory can take up to half an hour. With async_delete(),
+    the delete call will return almost immediately.
+
+    Under the covers, this is implemented by first synchronously renaming the file or directory to a unique name
+    inside of a temporary directory. After that, we launch an asynchronous process that deletes that file/directory.
+    This asynchronous process does not die when the invoking process (this process) exits/dies.
+
+    :param path: the absolute path to the file or directory to asynchronously delete
+    :type path: str
+    """
+    if os.path.isdir(path):
+        new_temp_path = tempfile.mkdtemp(prefix='async_delete_directory')
+    else:
+        _, new_temp_path = tempfile.mkstemp(prefix='async_delete_file')
+
+    shutil.move(path, new_temp_path)
+    subprocess.Popen("rm -rf {}".format(new_temp_path), shell=True)
 
 def create_dir(dir_path, mode=None):
     """

--- a/app/util/fs.py
+++ b/app/util/fs.py
@@ -4,6 +4,7 @@ import tarfile
 import tempfile
 import subprocess
 
+
 def async_delete(path):
     """
     Asynchronously delete a file or a directory. This functionality is handy for deleting large directories.
@@ -17,13 +18,10 @@ def async_delete(path):
     :param path: the absolute path to the file or directory to asynchronously delete
     :type path: str
     """
-    if os.path.isdir(path):
-        new_temp_path = tempfile.mkdtemp(prefix='async_delete_directory')
-    else:
-        _, new_temp_path = tempfile.mkstemp(prefix='async_delete_file')
-
+    new_temp_path = tempfile.mkdtemp(prefix='async_delete_directory')
     shutil.move(path, new_temp_path)
     subprocess.Popen(['rm', '-rf', new_temp_path])
+
 
 def create_dir(dir_path, mode=None):
     """

--- a/test/unit/master/test_cluster_master.py
+++ b/test/unit/master/test_cluster_master.py
@@ -16,6 +16,7 @@ class TestClusterMaster(BaseUnitTestCase):
     def setUp(self):
         super().setUp()
         self.patch('app.util.fs.create_dir')
+        self.patch('app.util.fs.async_delete')
         self.patch('shutil.rmtree')
 
     def test_updating_slave_to_idle_state_marks_build_finished_when_slaves_are_done(self):

--- a/test/unit/master/test_cluster_master.py
+++ b/test/unit/master/test_cluster_master.py
@@ -17,7 +17,6 @@ class TestClusterMaster(BaseUnitTestCase):
         super().setUp()
         self.patch('app.util.fs.create_dir')
         self.patch('app.util.fs.async_delete')
-        self.patch('shutil.rmtree')
 
     def test_updating_slave_to_idle_state_marks_build_finished_when_slaves_are_done(self):
         master = ClusterMaster()

--- a/test/unit/util/test_fs.py
+++ b/test/unit/util/test_fs.py
@@ -1,0 +1,16 @@
+from app.util import fs
+from test.framework.base_unit_test_case import BaseUnitTestCase
+
+
+class TestFs(BaseUnitTestCase):
+
+    def test_async_delete_calls_correct_commands(self):
+        popen_mock = self.patch('subprocess.Popen')
+        move_mock = self.patch('shutil.move')
+        self.patch('os.path.isdir').return_value = True
+        mkdtemp_mock = self.patch('tempfile.mkdtemp')
+        mkdtemp_mock.return_value = '/tmp/dir'
+        fs.async_delete('/some/dir')
+
+        move_mock.assert_called_with('/some/dir', '/tmp/dir')
+        popen_mock.assert_called_with(['rm', '-rf', '/tmp/dir'])


### PR DESCRIPTION
This command often fails the first time it is run, as one of the actions of the deploy functionality is to delete all of the build results. In the Box CI environment, this can take upwards of twenty minutes.

In order to remedy this, we should rename/move the results directory and asynchronously delete the directory in a process that won't die when the main process dies.