### PR TITLE
Expose top-level API representation for services

### DIFF
--- a/app/slave/cluster_slave.py
+++ b/app/slave/cluster_slave.py
@@ -56,10 +56,9 @@ class ClusterSlave(object):
         Gets a dict representing this resource which can be returned in an API response.
         :rtype: dict [str, mixed]
         """
-        # todo: add this to the ClusterSlave api response
         executors_representation = [executor.api_representation() for executor in self.executors_by_id.values()]
         return {
-            'connected': str(self._is_connected()),
+            'connected': self._is_connected(),
             'master_url': self._master_url,
             'current_build_id': self._current_build_id,
             'slave_id': self._slave_id,

--- a/app/web_framework/cluster_master_application.py
+++ b/app/web_framework/cluster_master_application.py
@@ -65,7 +65,11 @@ class _RootHandler(_ClusterMasterBaseHandler):
 
 
 class _APIVersionOneHandler(_ClusterMasterBaseHandler):
-    pass
+    def get(self):
+        response = {
+            'master': self._cluster_master.api_representation(),
+        }
+        self.write(response)
 
 
 class _VersionHandler(_ClusterMasterBaseHandler):

--- a/app/web_framework/cluster_slave_application.py
+++ b/app/web_framework/cluster_slave_application.py
@@ -57,7 +57,11 @@ class _RootHandler(_ClusterSlaveBaseHandler):
 
 
 class _APIVersionOneHandler(_ClusterSlaveBaseHandler):
-    pass
+    def get(self):
+        response = {
+            'slave': self._cluster_slave.api_representation(),
+        }
+        self.write(response)
 
 
 class _VersionHandler(_ClusterSlaveBaseHandler):


### PR DESCRIPTION
This just exposes the api_representation() methods that already exist
in the ClusterMaster and ClusterSlave classes. Before this change,
these methods were not used anywhere.