### PR TITLE
Executing setup_build before atomizer for request handling on the master?

### DIFF
--- a/app/master/serial_request_handler.py
+++ b/app/master/serial_request_handler.py
@@ -53,7 +53,7 @@ class SerialRequestHandler(object):
             raise BuildProjectError('Build failed due to an invalid build type.')
 
         self._logger.info('Fetching project for build {}.', build_id)
-        project_type.setup_build()
+        project_type.fetch_project()
 
         self._logger.info('Successfully fetched project for build {}.', build_id)
         job_config = project_type.job_config()

--- a/app/project_type/directory.py
+++ b/app/project_type/directory.py
@@ -35,7 +35,7 @@ class Directory(ProjectType):
         self.project_directory = os.path.abspath(project_directory)
         self._logger.debug('Project directory is {}'.format(project_directory))
 
-    def _setup_build(self):
+    def _fetch_project(self):
         check_command = 'test -d "{}"'.format(self.project_directory)
         output, exit_code = self.execute_command_in_project(check_command, cwd='/')
         if exit_code != 0:

--- a/app/project_type/docker.py
+++ b/app/project_type/docker.py
@@ -51,7 +51,7 @@ class Docker(ProjectType):
 
         self._container = DockerContainer(image, user, host, mounted_volumes)
 
-    def _setup_build(self):
+    def _fetch_project(self):
         pull_command = 'docker pull {}'.format(self._image)
         self._execute_in_project_and_raise_on_failure(pull_command, 'Could not pull Docker container.')
 

--- a/app/project_type/git.py
+++ b/app/project_type/git.py
@@ -123,7 +123,7 @@ class Git(ProjectType):
         os.symlink(actual_project_directory, build_project_directory)
         self.project_directory = build_project_directory
 
-    def _setup_build(self):
+    def _fetch_project(self):
         """
         Clones the project if necessary, fetches from the remote repo and resets to the requested commit
         """

--- a/app/slave/cluster_slave.py
+++ b/app/slave/cluster_slave.py
@@ -97,7 +97,7 @@ class ClusterSlave(object):
             raise RuntimeError('Slave tried to setup build but not all executors are idle. ({}/{} executors idle.)'
                                .format(self._idle_executors.qsize(), self._num_executors))
 
-        # Collect all the executors to pass to project_type.setup_build(). This will create a new project_type for
+        # Collect all the executors to pass to project_type.fetch_project(). This will create a new project_type for
         # each executor (for subjob-level operations).
         executors = list(self._idle_executors.queue)
         SafeThread(
@@ -117,7 +117,8 @@ class ClusterSlave(object):
         # todo(joey): It's strange that the project_type is setting up the executors, which in turn set up projects.
         # todo(joey): I think this can be untangled a bit -- we should call executor.configure_project_type() here.
         try:
-            self._project_type.setup_build(executors, project_type_params)
+            self._project_type.fetch_project(executors, project_type_params)
+            self._project_type.run_job_config_setup()
 
         except SetupFailureError as ex:
             self._logger.error(ex)

--- a/test/unit/project_type/test_git.py
+++ b/test/unit/project_type/test_git.py
@@ -143,7 +143,7 @@ class TestGit(BaseUnitTestCase):
 
         self.assertEqual(repo_directory, '/tmp/timings/source_control.cr.com1234/master')
 
-    def test_setup_build_when_existing_repo_is_shallow_deletes_repo(self):
+    def test_fetch_project_when_existing_repo_is_shallow_deletes_repo(self):
         url = 'url'
         repo_path = 'repo_path'
         git = Git(url)
@@ -155,10 +155,10 @@ class TestGit(BaseUnitTestCase):
         mock_fs = self.patch('app.project_type.git.fs')
         mock_rmtree = self.patch('shutil.rmtree')
         git._execute_git_remote_command = Mock()
-        mock_fs.create_dir.call_count = 0  # only measure calls made in _setup_build
+        mock_fs.create_dir.call_count = 0  # only measure calls made in _fetch_project
         mock_rmtree.call_count = 0
 
-        git._setup_build()
+        git._fetch_project()
 
         self.assertEqual(mock_fs.create_dir.call_count, 1)
         self.assertEqual(mock_rmtree.call_count, 1)


### PR DESCRIPTION
I've noticed that the serial request handler takes a while to atomize some of our builds, and I'm guessing that it's because the setup_build step is run before every atomization, and setup_build can take a long time to run at times.

How does everyone feel about not running setup_build before atomization?