### PR TITLE
In slave allocation loop, do not take down master if slave goes down

### DIFF
--- a/app/master/cluster_master.py
+++ b/app/master/cluster_master.py
@@ -179,7 +179,7 @@ class ClusterMaster(object):
         """
         # Mark slave dead. We do not remove it from the list of all slaves. We also do not remove it from idle_slaves;
         # that will happen during slave allocation.
-        slave.is_alive = False
+        slave.set_is_alive(False)
         # todo: Fail any currently executing subjobs still executing on this slave.
         self._logger.info('Slave on {} was disconnected. (id: {})', slave.url, slave.id)
 
@@ -337,9 +337,11 @@ class ClusterMaster(object):
 
             while build_waiting_for_slave.needs_more_slaves():
                 claimed_slave = self._idle_slaves.get()
+
                 # Remove dead slaves from the idle queue
-                if not claimed_slave.is_alive:
+                if not claimed_slave.is_alive(use_cached=False):
                     continue
+
                 # The build may have completed while we were waiting for an idle slave, so check one more time.
                 if build_waiting_for_slave.needs_more_slaves():
                     # Potential race condition here!  If the build completes after the if statement is checked,

--- a/test/unit/master/test_cluster_master.py
+++ b/test/unit/master/test_cluster_master.py
@@ -119,11 +119,11 @@ class TestClusterMaster(BaseUnitTestCase):
         slave_url = 'raphael.turtles.gov'
         master.connect_new_slave(slave_url, 10)
         slave = master.get_slave(slave_url=slave_url)
-        self.assertTrue(slave.is_alive)
+        self.assertTrue(slave.is_alive())
 
         master.handle_slave_state_update(slave, SlaveState.DISCONNECTED)
 
-        self.assertFalse(slave.is_alive)
+        self.assertFalse(slave.is_alive())
 
     def test_updating_slave_to_setup_completed_state_should_tell_build_to_begin_subjob_execution(self):
         master = ClusterMaster()

--- a/test/unit/slave/test_cluster_slave.py
+++ b/test/unit/slave/test_cluster_slave.py
@@ -62,7 +62,7 @@ class TestClusterSlave(BaseUnitTestCase):
 
         slave = self._create_cluster_slave()
         slave.connect_to_master(self._FAKE_MASTER_URL)
-        slave._send_master_disconnect_notification()
+        slave._disconnect_from_master()
 
         # expect a connect call and a connectivity call, and if the master is responsive also expect a disconnect call
         expected_network_calls = [


### PR DESCRIPTION
Currently if the slave service goes down, and the master tries to allocate a subjob to that slave, the whole master service gets taken down.

Instead, catch the network exception in the slave allocation loop, and mark the slave as offline in the master's bookkeeping data structure.