### PR TITLE
Update nose requirement to 1.3.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ coverage==3.7.1
 cx_Freeze==4.3.3
 genty==1.1.0
 Logbook==0.7.0
-nose==1.3.3
+nose==1.3.4
 pexpect==3.3
 psutil==2.1.2
 pylint==1.3.1


### PR DESCRIPTION
This will make our Travis CI builds run a little faster. Right now,
the `pip install -r requirements.txt` uninstalls 1.3.4 to install
1.3.3.