### PR TITLE
Update tornado requirement to 4.0.2

### DIFF
--- a/app/web_framework/cluster_base_handler.py
+++ b/app/web_framework/cluster_base_handler.py
@@ -8,6 +8,9 @@ from app.util.conf.configuration import Configuration
 from app.util.exceptions import AuthenticationError, BadRequestError, ItemNotFoundError, ItemNotReadyError
 from app.util.network import ENCODED_BODY
 
+# pylint: disable=abstract-method
+# "abstract-method" is disabled because it triggers on an optional abstract method in tornado.web.RequestHandler.
+
 
 class ClusterBaseHandler(tornado.web.RequestHandler):
 

--- a/app/web_framework/cluster_master_application.py
+++ b/app/web_framework/cluster_master_application.py
@@ -9,6 +9,9 @@ from app.web_framework.cluster_application import ClusterApplication
 from app.web_framework.cluster_base_handler import ClusterBaseHandler
 from app.web_framework.route_node import RouteNode
 
+# pylint: disable=abstract-method
+# "abstract-method" is disabled because it triggers on an optional abstract method in tornado.web.RequestHandler.
+
 
 class ClusterMasterApplication(ClusterApplication):
 

--- a/app/web_framework/cluster_slave_application.py
+++ b/app/web_framework/cluster_slave_application.py
@@ -6,6 +6,9 @@ from app.web_framework.cluster_application import ClusterApplication
 from app.web_framework.cluster_base_handler import ClusterBaseHandler
 from app.web_framework.route_node import RouteNode
 
+# pylint: disable=abstract-method
+# "abstract-method" is disabled because it triggers on an optional abstract method in tornado.web.RequestHandler.
+
 
 class ClusterSlaveApplication(ClusterApplication):
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ pylint==1.3.1
 PyYAML==3.11
 requests==2.3.0
 termcolor==1.1.0
-tornado==3.2.2
+tornado==4.0.2

--- a/test/unit/web_framework/test_cluster_base_handler.py
+++ b/test/unit/web_framework/test_cluster_base_handler.py
@@ -18,7 +18,7 @@ class TestClusterBaseHandler(BaseUnitTestCase):
     )
     def test_set_default_headers_should_not_set_origin_header(self, request_origin, cors_conf_value):
         mock_application = MagicMock(spec_set=ClusterApplication())
-        mock_request = MagicMock(spec=tornado.httpserver.HTTPRequest, headers={})
+        mock_request = MagicMock(headers={})
         if cors_conf_value:
             Configuration['cors_allowed_origins_regex'] = cors_conf_value
         if request_origin:
@@ -37,7 +37,7 @@ class TestClusterBaseHandler(BaseUnitTestCase):
     )
     def test_set_default_headers_should_set_origin_header(self, request_origin, cors_conf_value):
         mock_application = MagicMock(spec_set=ClusterApplication())
-        mock_request = MagicMock(spec=tornado.httpserver.HTTPRequest, headers={})
+        mock_request = MagicMock(headers={})
         Configuration['cors_allowed_origins_regex'] = cors_conf_value
         mock_request.headers['Origin'] = request_origin
 


### PR DESCRIPTION
Tornado 4.0 was released last July, so this should be a pretty safe
update. None of the 3.2.2 to 4.0.2 changes documented in the changelog
should affect us.