### PR TITLE
Point stdout and stderr to dev/null for async Popen calls

### DIFF
--- a/app/util/shell/local.py
+++ b/app/util/shell/local.py
@@ -1,5 +1,5 @@
 import shutil
-from subprocess import Popen, PIPE
+from subprocess import Popen, PIPE, DEVNULL
 
 from app.util.log import get_logger
 from app.util.shell.shell_client import ShellClient, Response, EmptyResponse
@@ -18,7 +18,7 @@ class LocalShellClient(ShellClient):
         """
         # todo investigate why this assignment is required for launching async operations using Popen
         self._logger.debug('popen async [{}:{}]: {}'.format(self.user, self.host, command))
-        proc = Popen(command, shell=True, stdout=PIPE, stderr=PIPE)
+        proc = Popen(command, shell=True, stdout=DEVNULL, stderr=DEVNULL)
         return EmptyResponse()
 
     def _exec_command_on_client_blocking(self, command):

--- a/app/util/shell/remote.py
+++ b/app/util/shell/remote.py
@@ -1,4 +1,4 @@
-from subprocess import Popen, PIPE
+from subprocess import Popen, PIPE, DEVNULL
 
 from app.util.log import get_logger
 from app.util.shell.shell_client import ShellClient, Response, EmptyResponse
@@ -16,7 +16,7 @@ class RemoteShellClient(ShellClient):
         """
         escaped_command = self._escaped_ssh_command(command)
         self._logger.debug('SSH popen async [{}:{}]: {}'.format(self.user, self.host, escaped_command))
-        proc = Popen(escaped_command, shell=True, stdout=PIPE, stderr=PIPE)
+        proc = Popen(escaped_command, shell=True, stdout=DEVNULL, stderr=DEVNULL)
         return EmptyResponse()
 
     def _exec_command_on_client_blocking(self, command):


### PR DESCRIPTION
This fixes an issue where multiprocessing would raise an exception due
to the stdout stream being closed. The exception would only occur when
ClusterRunner had been deployed via 'clusterrunner deploy'.

This is a cleaner way to launch async subprocesses since we explicitly
will not connect to the spawned process's stdout or stderr streams.