### PR TITLE
Add more logging around build requests

### DIFF
--- a/app/util/conf/base_config_loader.py
+++ b/app/util/conf/base_config_loader.py
@@ -69,7 +69,7 @@ class BaseConfigLoader(object):
         conf.set('log_filename', 'clusterrunner_default.log')
         conf.set('eventlog_filename', 'eventlog_default.log')
         conf.set('eventlog_file', None)
-        conf.set('max_eventlog_file_size', 1024 * 1024 * 10)  # 10mb
+        conf.set('max_eventlog_file_size', 1024 * 1024 * 50)  # 50mb
         conf.set('max_eventlog_file_backups', 5)
         conf.set('hostname', platform.node())
         conf.set('master_hostname', 'localhost')

--- a/test/unit/util/test_analytics.py
+++ b/test/unit/util/test_analytics.py
@@ -56,3 +56,14 @@ class TestAnalytics(BaseUnitTestCase):
     def test_get_events_returns_none_when_no_initialization_performed(self):
         events = analytics.get_events()
         self.assertEqual(events, None, 'get_events() should return None if no initialization was done.')
+
+    def test_record_event_with_log_msg_logs_correct_message(self):
+        analytics.record_event(
+            'SOME_EVENT_TAG',
+            log_msg='Build {build_id} was looking pretty {build_adjective}!',
+            build_id=12,
+            build_adjective='freaky')
+
+        self.assertTrue(
+            self.log_handler.has_info('Build 12 was looking pretty freaky!'),
+            'Passing a log_msg param to record_event() should log an info-level message to the application log.')


### PR DESCRIPTION
This change adds more logs in both the human-readable app log and the
(machine-readable) event log. Added logs are all related to collecting
timing data for build requests and preparation/atomization.