### PR TITLE
Builds should never hang if all subjobs complete

### DIFF
--- a/app/master/slave.py
+++ b/app/master/slave.py
@@ -34,6 +34,7 @@ class Slave(object):
             'num_executors': self.num_executors,
             'num_executors_in_use': self.num_executors_in_use(),
             'current_build_id': self.current_build_id,
+            'is_alive': self.is_alive(),
         }
 
     def mark_as_idle(self):

--- a/test/functional/test_cluster_basic.py
+++ b/test/functional/test_cluster_basic.py
@@ -17,7 +17,7 @@ class TestClusterBasic(BaseFunctionalTestCase):
     )
     def test_basic_directory_configs_end_to_end(self, test_job_config):
         master = self.cluster.start_master()
-        self.cluster.start_slave()
+        slave = self.cluster.start_slave()
 
         project_dir = tempfile.TemporaryDirectory()
         build_resp = master.post_new_build({
@@ -27,6 +27,7 @@ class TestClusterBasic(BaseFunctionalTestCase):
         })
         build_id = build_resp['build_id']
         master.block_until_build_finished(build_id, timeout=10)
+        slave.block_until_idle(timeout=5)  # ensure slave teardown has finished before making assertions
 
         if test_job_config.expected_to_fail:
             self.assert_build_has_failure_status(build_id=build_id)


### PR DESCRIPTION
Currently, if a slave fails during setup_build or teardown_build, the
build will be stuck in BUILDING state forever, even if all subjobs
complete successfully on other slaves. (Issue #65)

The reason is that we have code that prevents a build from finishing
until all slaves ever assigned to that build have successfully
completed teardown_build commands. This is actually unnecessary - a
build should be considered complete as soon as its last subjob
completes.

This change removes the code that blocks a build from finishing until
teardown_build is complete. It also clears a slave's `current_build_id`
field when a slave disconnects (since a disconnected slave is not
working on any build.)

Fixes #65.