### PR TITLE
Add unique project_id() method to the project_type classes.

### DIFF
--- a/app/project_type/directory.py
+++ b/app/project_type/directory.py
@@ -63,3 +63,6 @@ class Directory(ProjectType):
             timings_subdirectory,
             '{}.timing.json'.format(job_name)
         )
+
+    def project_id(self):
+        return self.project_directory

--- a/app/project_type/docker.py
+++ b/app/project_type/docker.py
@@ -141,6 +141,11 @@ class Docker(ProjectType):
         """
         pass
 
+    def project_id(self):
+        # Docker cannot fetch multiple containers in parallel, so the project_id for all docker-project_type
+        # builds must be done serially.
+        return 'docker'
+
     def _remove_file_system_unfriendly_characters(self, unescaped_path):
         """
         Escape the string unescaped_path to be POSIX directory format compliant.

--- a/app/project_type/git.py
+++ b/app/project_type/git.py
@@ -185,6 +185,9 @@ class Git(ProjectType):
         """
         return os.path.join(self._timing_file_directory, "{}.timing.json".format(job_name))
 
+    def project_id(self):
+        return self._repo_directory
+
 
 class _GitRemoteCommandExecutor(object):
     """

--- a/app/project_type/project_type.py
+++ b/app/project_type/project_type.py
@@ -396,6 +396,15 @@ class ProjectType(object):
 
         return arguments_info
 
+    def project_id(self):
+        """
+        Get a string that uniquely identifies the project involved.  Build requests for the same project will have
+        their own serial request handler.  This allows us to parallelize the atomization of builds which are for
+        different projects (since their fetching and atomization commands will not collide).
+        :return: string
+        """
+        raise NotImplementedError
+
     def _run_remote_file_setup(self):
         """
         Fetches remote files


### PR DESCRIPTION
Again, essentially another subset of Duke's build. This one is really benign though, and is essentially a no-op.

For every unique project_id(), the builds will have their own request handler.