### PR TITLE
Pull out functionality of new build request handling into its own class.

### DIFF
--- a/app/master/build_request_handler.py
+++ b/app/master/build_request_handler.py
@@ -1,20 +1,91 @@
 import json
 import os
+from queue import Queue
 
 from app.master.atom_grouper import AtomGrouper
 from app.master.build_request import BuildRequest
 from app.master.subjob import Subjob
 from app.master.time_based_atom_grouper import TimeBasedAtomGrouper
-from app.util.log import get_logger
 from app.project_type.project_type import ProjectType
+from app.util import analytics
+from app.util.log import get_logger
+from app.util.safe_thread import SafeThread
 
 
-class SerialRequestHandler(object):
+class BuildRequestHandler(object):
+    """
+    The BuildRequestHandler class is responsible for preparing a non-prepared build.
+
+    Implementation notes:
+
+    This class manages two critical Queue's in ClusterRunner: request_queue and builds_waiting_for_slaves.
+
+    The request_queue is the queue of non-prepared Build instances that the BuildRequestHandler has
+    yet to prepare. This queue is populated by the ClusterMaster instance.
+
+    The builds_waiting_for_slaves queue is the queue of prepared Build instances that the
+    BuildRequestHandler has completed build preparation for, and is waiting for the SlaveAllocator (a separate
+    entity) to pull Builds from.
+
+    All of the input of builds come through self.handle_build_request() calls, and all of the output
+    of builds go through self.next_prepared_build() calls.
+    """
 
     def __init__(self):
         self._logger = get_logger(__name__)
+        self._builds_waiting_for_slaves = Queue()
+        self._request_queue = Queue()
+        self._request_queue_worker_thread = SafeThread(
+            target=self._build_preparation_loop, name='RequestHandlerLoop', daemon=True)
 
-    def handle_request(self, build):
+    def start(self):
+        """
+        Start the infinite loop that will accept unprepared builds and put them through build preparation.
+        """
+        if self._request_queue_worker_thread.is_alive():
+            raise RuntimeError('Error: build request handler loop was asked to start when its already running.')
+        self._request_queue_worker_thread.start()
+
+    def handle_build_request(self, build):
+        """
+        :param build: the requested build
+        :type build: Build
+        """
+        self._request_queue.put(build)
+        analytics.record_event(analytics.BUILD_REQUEST_QUEUED, build_id=build.build_id(),
+                               log_msg='Queued request for build {build_id}.')
+
+    def next_prepared_build(self):
+        """
+        Get the next build that has successfully completed build preparation.
+
+        This is a blocking call--if there are no more builds that have completed build preparation and this
+        method gets invoked, the execution will hang until the next build has completed build preparation.
+
+        :rtype: Build
+        """
+        return self._builds_waiting_for_slaves.get()
+
+    def _build_preparation_loop(self):
+        """
+        Grabs a build off the request_queue (populated by self.handle_build_request()), prepares it,
+        and puts that build onto the self.builds_waiting_for_slaves queue.
+        """
+        while True:
+            build = self._request_queue.get()
+            analytics.record_event(analytics.BUILD_PREPARE_START, build_id=build.build_id(),
+                                   log_msg='Build preparation loop is handling request for build {build_id}.')
+            try:
+                self._prepare_build(build)
+                if not build.has_error:
+                    analytics.record_event(analytics.BUILD_PREPARE_FINISH, build_id=build.build_id(),
+                                           log_msg='Build {build_id} successfully prepared and waiting for slaves.')
+                    self._builds_waiting_for_slaves.put(build)
+            except Exception as ex:  # pylint: disable=broad-except
+                build.mark_failed(str(ex))
+                self._logger.exception('Could not handle build request for build {}.'.format(build.build_id()))
+
+    def _prepare_build(self, build):
         """
         Prepare a Build to be distributed across slaves.
 
@@ -46,7 +117,6 @@ class SerialRequestHandler(object):
 
     def _compute_subjobs_for_build(self, build_id, job_config, project_type):
         """
-
         :type build_id: int
         :type job_config: JobConfig
         :param project_type: the docker, directory, or git repo project_type that this build is running in

--- a/app/master/slave_allocator.py
+++ b/app/master/slave_allocator.py
@@ -1,0 +1,65 @@
+from app.util.log import get_logger
+from app.util.ordered_set_queue import OrderedSetQueue
+from app.util.safe_thread import SafeThread
+
+
+class SlaveAllocator(object):
+    """
+    The SlaveAllocator class is responsible for allocating slaves to prepared builds.
+    """
+
+    def __init__(self, build_request_handler):
+        """
+        :type build_request_handler: BuildRequestHandler
+        """
+        self._logger = get_logger(__name__)
+        self._build_request_handler = build_request_handler
+        self._idle_slaves = OrderedSetQueue()
+        self._allocation_thread = SafeThread(
+            target=self._slave_allocation_loop, name='SlaveAllocationLoop', daemon=True)
+
+    def start(self):
+        """
+        Start the infinite loop that will pull off prepared builds from a synchronized queue
+        and allocate them slaves.
+        """
+        if self._allocation_thread.is_alive():
+            raise RuntimeError('Error: slave allocation loop was asked to start when its already running.')
+        self._allocation_thread.start()
+
+    def _slave_allocation_loop(self):
+        """
+        Builds wait in line for more slaves. This method executes in the background on another thread and
+        watches for idle slaves, then gives them out to the waiting builds.
+        """
+        while True:
+            # This is a blocking call that will block until there is a prepared build.
+            build_waiting_for_slave = self._build_request_handler.next_prepared_build()
+
+            while build_waiting_for_slave.needs_more_slaves():
+                claimed_slave = self._idle_slaves.get()
+
+                # Remove dead slaves from the idle queue
+                if not claimed_slave.is_alive(use_cached=False):
+                    continue
+
+                # The build may have completed while we were waiting for an idle slave, so check one more time.
+                if build_waiting_for_slave.needs_more_slaves():
+                    # Potential race condition here!  If the build completes after the if statement is checked,
+                    # a slave will be allocated needlessly (and run slave.setup(), which can be significant work).
+                    self._logger.info('Allocating slave {} to build {}.',
+                                      claimed_slave.url, build_waiting_for_slave.build_id())
+                    build_waiting_for_slave.allocate_slave(claimed_slave)
+                else:
+                    self.add_idle_slave(claimed_slave)
+
+            self._logger.info('Done allocating slaves for build {}.', build_waiting_for_slave.build_id())
+
+    def add_idle_slave(self, slave):
+        """
+        Add a slave to the idle queue.
+
+        :type slave: Slave
+        """
+        slave.mark_as_idle()
+        self._idle_slaves.put(slave)


### PR DESCRIPTION
The ClusterMaster class is starting to bloat a little bit, and before we
add any more complexity to the class, it'd be good to separate the logic
out.

- Created a BuildRequestHandler class
- Created a SlaveAllocator class
- The serial_request_handler class is now a part of the
  BuildRequestHandler class