### PR TITLE
Add pep8 and makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,20 +4,12 @@ python:
 
 # each line defined in env will create a new parallel test job on Travis
 env:
-  - DO_LINT=true DO_UNIT=true DO_FUNCTIONAL=false
-  - DO_LINT=false DO_UNIT=false DO_FUNCTIONAL=true
+  - TARGETS="lint test-unit"
+  - TARGETS="test-functional test-unit-via-clusterrunner"
 
 install:
-  - pip install -r requirements.txt
+  - make init
 
 script:
-  - DO_PYLINT_CMD="pylint app"
-  - TEST_UNIT_CMD="nosetests -v test/unit"
-  - TEST_FUNC_CMD="nosetests -s -v test/functional"
-  - TEST_BUILD_UNIT_CMD="./main.py build"
   - export CR_VERBOSE=1  # turns on stdout logging for master and slave services during functional tests
-
-  - if [[ $DO_LINT == true ]]; then $DO_PYLINT_CMD; fi
-  - if [[ $DO_UNIT == true ]]; then $TEST_UNIT_CMD; fi
-  - if [[ $DO_FUNCTIONAL == true ]]; then $TEST_FUNC_CMD; fi
-  - if [[ $DO_FUNCTIONAL == true ]]; then $TEST_BUILD_UNIT_CMD; fi
+  - make $TARGETS

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,37 @@
+.PHONY: all lint test init pylint pep8 test-unit test-unit-via-clusterrunner test-functional freeze
+
+# Macro for printing a colored message to stdout
+print_msg = @printf "\n\033[1;34m***%s***\033[0m\n" "$(1)"
+
+all: lint test
+lint: pylint pep8
+test: test-unit test-functional
+
+init:
+	$(call print_msg, Installing requirements... )
+	pip install -r requirements.txt
+
+pylint:
+	$(call print_msg, Running pylint... )
+	pylint app
+
+pep8:
+	$(call print_msg, Running pep8... )
+	pep8 --max-line-length=160 app
+
+test-unit:
+	$(call print_msg, Running unit tests... )
+	nosetests -v test/unit
+
+test-unit-via-clusterrunner:
+	$(call print_msg, Running unit tests via ClusterRunner... )
+	./main.py build
+	./main.py stop
+
+test-functional:
+	$(call print_msg, Running functional tests... )
+	nosetests -s -v test/functional
+
+freeze:
+	$(call print_msg, Freezing... )
+	python setup.py build

--- a/app/util/fs.py
+++ b/app/util/fs.py
@@ -115,6 +115,7 @@ def compress_directories(target_dirs_to_archive_paths, tarfile_path):
 
             tar.add(target_dir, arcname=archive_name)
 
+
 def remove_invalid_path_characters(path):
     """
     :param path: the path that may contain invalid characters

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ cx_Freeze==4.3.3
 genty==1.1.0
 Logbook==0.7.0
 nose==1.3.4
+pep8==1.5.7
 psutil==2.1.2
 pylint==1.3.1
 PyYAML==3.11


### PR DESCRIPTION
This adds the pep8 linter which catches a few things that pylint does
not. Also, to simplify running lint and tests both locally and on
Travis CI, I added a makefile.

This simplifies the act of running the various tests and linters we
have without needing to add a bunch of bash scripts to the repo:
 - `make` to run lint and all tests (probably the most common thing)
 - `make lint` or `make test` to just run either lint or tests
 - `make freeze` to run the cx_Freeze build process

The makefile approach is roughly based on what [HTTPie](https://github.com/jakubroztocil/httpie/blob/master/Makefile) is doing with
their makefile and .travis.yml.