### PR TITLE
Add an executor_index for the entire build

### DIFF
--- a/app/master/build.py
+++ b/app/master/build.py
@@ -136,9 +136,14 @@ class Build(object):
         :type slave: Slave
         """
         self._slaves_allocated.append(slave)
-        self._num_executors_allocated += min(slave.num_executors, self._max_executors_per_slave)
 
-        slave.setup(self.build_id(), project_type_params=self.build_request.build_parameters())
+        slave.setup(
+            self.build_id(),
+            project_type_params=self.build_request.build_parameters(),
+            num_executors_already_allocated=self._num_executors_allocated
+        )
+
+        self._num_executors_allocated += min(slave.num_executors, self._max_executors_per_slave)
 
     def all_subjobs(self):
         """

--- a/app/master/build.py
+++ b/app/master/build.py
@@ -140,7 +140,7 @@ class Build(object):
         slave.setup(
             self.build_id(),
             project_type_params=self.build_request.build_parameters(),
-            num_executors_already_allocated=self._num_executors_allocated
+            build_executor_start_index=self._num_executors_allocated
         )
 
         self._num_executors_allocated += min(slave.num_executors, self._max_executors_per_slave)

--- a/app/master/slave.py
+++ b/app/master/slave.py
@@ -48,7 +48,7 @@ class Slave(object):
 
         self.current_build_id = None
 
-    def setup(self, build_id, project_type_params):
+    def setup(self, build_id, project_type_params, num_executors_already_allocated):
         """
         Execute a setup command on the slave for the specified build. The command is executed asynchronously from the
         perspective of this method, but any subjobs will block until the slave finishes executing the setup command.
@@ -63,6 +63,7 @@ class Slave(object):
         slave_project_type_params = util.project_type_params_for_slave(project_type_params)
         post_data = {
             'project_type_params': slave_project_type_params,
+            'num_executors_already_allocated': num_executors_already_allocated,
         }
         self._network.post_with_digest(setup_url, post_data, Secret.get())
         self.current_build_id = build_id

--- a/app/master/slave.py
+++ b/app/master/slave.py
@@ -48,7 +48,7 @@ class Slave(object):
 
         self.current_build_id = None
 
-    def setup(self, build_id, project_type_params, num_executors_already_allocated):
+    def setup(self, build_id, project_type_params, build_executor_start_index):
         """
         Execute a setup command on the slave for the specified build. The command is executed asynchronously from the
         perspective of this method, but any subjobs will block until the slave finishes executing the setup command.
@@ -63,7 +63,7 @@ class Slave(object):
         slave_project_type_params = util.project_type_params_for_slave(project_type_params)
         post_data = {
             'project_type_params': slave_project_type_params,
-            'num_executors_already_allocated': num_executors_already_allocated,
+            'build_executor_start_index': build_executor_start_index,
         }
         self._network.post_with_digest(setup_url, post_data, Secret.get())
         self.current_build_id = build_id

--- a/app/project_type/project_type.py
+++ b/app/project_type/project_type.py
@@ -71,29 +71,18 @@ class ProjectType(object):
             config_contents = f.read()
         return config_contents
 
-    def fetch_project(self, executors=None, project_type_params=None):
+    def fetch_project(self):
         """
         Fetch the project onto the local machine.
 
         Runs once per machine per build. Runs the project_type's retrieve command (fetch, reset, etc) and produces
         a list of per-executor project_types.
-
-        :type executors: list [SubjobExecutor]
-        :type project_type_params: dict [str, str]
         """
-        if (executors is None) != (project_type_params is None):
-            raise RuntimeError('setup_build called with invalid params, either both executors and project_type_params '
-                               'should be set, or neither')
-
         self._fetch_project()
         self._logger.info('Build setup complete.')
 
         if self._remote_files:
             self._run_remote_file_setup()
-
-        # If executors were passed in, run configure_environment to do per-executor setup.
-        if executors and project_type_params:
-            self._setup_executors(executors, project_type_params)
 
     def _fetch_project(self):
         raise NotImplementedError
@@ -144,17 +133,6 @@ class ProjectType(object):
                 raise TeardownFailureError('Build teardown failed!\nCommand:\n"{}"\n\nOutput:\n{}'
                                            .format(job_config.teardown_build, output))
             self._logger.info('Build teardown completed successfully.')
-
-    def _setup_executors(self, executors, project_type_params):
-        """
-        Given the executors, run the job config setup commands.  Override this to specify different behavior per
-        project_type type.
-
-        :type executors: list [SubjobExecutor]
-        :type project_type_params: dict [str, str]
-        """
-        for executor in executors:
-            executor.configure_project_type(project_type_params)
 
     def setup_executor(self):
         """

--- a/app/slave/cluster_slave.py
+++ b/app/slave/cluster_slave.py
@@ -72,7 +72,7 @@ class ClusterSlave(object):
         """
         return 'Slave service is up. <Port: {}>'.format(self.port)
 
-    def setup_build(self, build_id, project_type_params, num_executors_already_allocated):
+    def setup_build(self, build_id, project_type_params, build_executor_start_index):
         """
         Usually called once per build to do build-specific setup. Will block any subjobs from executing until setup
         completes. The actual setup is performed on another thread and will unblock subjobs (via an Event) once it
@@ -82,9 +82,9 @@ class ClusterSlave(object):
         :type build_id: int
         :param project_type_params: The parameters that define the project_type this build will execute in
         :type project_type_params: dict
-        :param num_executors_already_allocated: How many executors have alreayd been allocated on other slaves for
+        :param build_executor_start_index: How many executors have alreayd been allocated on other slaves for
         this build
-        :type num_executors_already_allocated: int
+        :type build_executor_start_index: int
         """
         self._logger.info('Executing setup for build {} (type: {}).', build_id, project_type_params.get('type'))
         self._current_build_id = build_id
@@ -104,19 +104,19 @@ class ClusterSlave(object):
         SafeThread(
             target=self._async_setup_build,
             name='Bld{}-Setup'.format(build_id),
-            args=(executors, project_type_params, num_executors_already_allocated)
+            args=(executors, project_type_params, build_executor_start_index)
         ).start()
 
-    def _async_setup_build(self, executors, project_type_params, num_executors_already_allocated):
+    def _async_setup_build(self, executors, project_type_params, build_executor_start_index):
         """
         Called from setup_build(). Do asynchronous setup for the build so that we can make the call to setup_build()
         non-blocking.
 
         :type executors: list[SubjobExecutor]
         :type project_type_params: dict
-        :type num_executors_already_allocated: int
+        :type build_executor_start_index: int
         """
-        self._base_executor_index = num_executors_already_allocated
+        self._base_executor_index = build_executor_start_index
         try:
             self._project_type.fetch_project()
             for executor in executors:
@@ -296,7 +296,8 @@ class ClusterSlave(object):
         subjob_event_data = {'build_id': build_id, 'subjob_id': subjob_id, 'executor_id': executor.id}
 
         analytics.record_event(analytics.SUBJOB_EXECUTION_START, **subjob_event_data)
-        results_file = executor.execute_subjob(build_id, subjob_id, subjob_artifact_dir, atomic_commands, self._base_executor_index)
+        results_file = executor.execute_subjob(build_id, subjob_id, subjob_artifact_dir, atomic_commands,
+                                               self._base_executor_index)
         analytics.record_event(analytics.SUBJOB_EXECUTION_FINISH, **subjob_event_data)
 
         results_url = self._master_api.url('build', build_id, 'subjob', subjob_id, 'result')

--- a/app/slave/subjob_executor.py
+++ b/app/slave/subjob_executor.py
@@ -20,6 +20,7 @@ class SubjobExecutor(object):
         self._logger = log.get_logger(__name__)
         self._current_build_id = None
         self._current_subjob_id = None
+        self._index_in_build = None
 
     def api_representation(self):
         """
@@ -48,7 +49,7 @@ class SubjobExecutor(object):
     def run_job_config_setup(self):
         self._project_type.run_job_config_setup()
 
-    def execute_subjob(self, build_id, subjob_id, subjob_artifact_dir, atomic_commands):
+    def execute_subjob(self, build_id, subjob_id, subjob_artifact_dir, atomic_commands, base_executor_index):
         """
         This is the method for executing a subjob. This performs the work required by executing the specified command,
         then archives the results into a single file and returns the filename.
@@ -57,6 +58,7 @@ class SubjobExecutor(object):
         :type subjob_id: int
         :type subjob_artifact_dir: str
         :type atomic_commands: list[str]
+        :type base_executor_index: int
         :rtype: str
         """
         self._logger.info('Executing subjob (Build {}, Subjob {})...', build_id, subjob_id)
@@ -82,6 +84,8 @@ class SubjobExecutor(object):
                 'ARTIFACT_DIR': atom_artifact_dir,
                 'ATOM_ID': atom_id,
                 'EXECUTOR_INDEX': self.id,
+                'MACHINE_EXECUTOR_INDEX': self.id,
+                'BUILD_EXECUTOR_INDEX': base_executor_index + self.id,
             }
 
             atom_artifact_dirs.append(atom_artifact_dir)

--- a/app/slave/subjob_executor.py
+++ b/app/slave/subjob_executor.py
@@ -83,7 +83,7 @@ class SubjobExecutor(object):
             atom_environment_vars = {
                 'ARTIFACT_DIR': atom_artifact_dir,
                 'ATOM_ID': atom_id,
-                'EXECUTOR_INDEX': self.id,
+                'EXECUTOR_INDEX': self.id,  # Deprecated, use MACHINE_EXECUTOR_INDEX
                 'MACHINE_EXECUTOR_INDEX': self.id,
                 'BUILD_EXECUTOR_INDEX': base_executor_index + self.id,
             }

--- a/app/web_framework/cluster_slave_application.py
+++ b/app/web_framework/cluster_slave_application.py
@@ -84,7 +84,8 @@ class _BuildSetupHandler(_ClusterSlaveBaseHandler):
     @authenticated
     def post(self, build_id):
         project_type_params = self.decoded_body.get('project_type_params')
-        self._cluster_slave.setup_build(int(build_id), project_type_params)
+        num_executors_already_allocated = self.decoded_body.get('num_executors_already_allocated')
+        self._cluster_slave.setup_build(int(build_id), project_type_params, int(num_executors_already_allocated))
         self._write_status()
 
 

--- a/app/web_framework/cluster_slave_application.py
+++ b/app/web_framework/cluster_slave_application.py
@@ -84,8 +84,8 @@ class _BuildSetupHandler(_ClusterSlaveBaseHandler):
     @authenticated
     def post(self, build_id):
         project_type_params = self.decoded_body.get('project_type_params')
-        num_executors_already_allocated = self.decoded_body.get('num_executors_already_allocated')
-        self._cluster_slave.setup_build(int(build_id), project_type_params, int(num_executors_already_allocated))
+        build_executor_start_index = self.decoded_body.get('build_executor_start_index')
+        self._cluster_slave.setup_build(int(build_id), project_type_params, int(build_executor_start_index))
         self._write_status()
 
 

--- a/test/unit/master/test_build.py
+++ b/test/unit/master/test_build.py
@@ -40,7 +40,7 @@ class TestBuild(BaseUnitTestCase):
         build.allocate_slave(mock_slave)
 
         # assert
-        mock_slave.setup.assert_called_once_with(build.build_id(), num_executors_already_allocated=0,
+        mock_slave.setup.assert_called_once_with(build.build_id(), build_executor_start_index=0,
                                                  project_type_params={'setup': fake_setup_command})
 
     def test_build_doesnt_use_more_than_max_executors(self):

--- a/test/unit/master/test_build.py
+++ b/test/unit/master/test_build.py
@@ -40,7 +40,8 @@ class TestBuild(BaseUnitTestCase):
         build.allocate_slave(mock_slave)
 
         # assert
-        mock_slave.setup.assert_called_once_with(build.build_id(), project_type_params={'setup': fake_setup_command})
+        mock_slave.setup.assert_called_once_with(build.build_id(), num_executors_already_allocated=0,
+                                                 project_type_params={'setup': fake_setup_command})
 
     def test_build_doesnt_use_more_than_max_executors(self):
         subjobs = self._create_subjobs()

--- a/test/unit/master/test_slave.py
+++ b/test/unit/master/test_slave.py
@@ -42,15 +42,16 @@ class TestSlave(BaseUnitTestCase):
         slave = self._create_slave()
         slave._network.post_with_digest = Mock()
 
-        slave.setup(1, {'type': 'git', 'url': 'http://{}'.format(remote_path)})
+        slave.setup(1, {'type': 'git', 'url': 'http://{}'.format(remote_path)}, 0)
 
         slave._network.post_with_digest.assert_called_with('http://{}/v1/build/1/setup'.format(self._FAKE_SLAVE_URL),
-                                                           {'project_type_params': {
-                                                               'url': 'ssh://{}{}/repos/master/{}'.format(
-                                                                   self._fake_hostname,
-                                                                   base_directory,
-                                                                   remote_path),
-                                                               'type': 'git'}}, Secret.get())
+                                                           {'num_executors_already_allocated': 0,
+                                                            'project_type_params': {
+                                                                'url': 'ssh://{}{}/repos/master/{}'.format(
+                                                                    self._fake_hostname,
+                                                                    base_directory,
+                                                                    remote_path),
+                                                                'type': 'git'}}, Secret.get())
 
     def test_is_alive_returns_cached_value_if_use_cache_is_true(self):
         slave = self._create_slave()

--- a/test/unit/master/test_slave.py
+++ b/test/unit/master/test_slave.py
@@ -45,7 +45,7 @@ class TestSlave(BaseUnitTestCase):
         slave.setup(1, {'type': 'git', 'url': 'http://{}'.format(remote_path)}, 0)
 
         slave._network.post_with_digest.assert_called_with('http://{}/v1/build/1/setup'.format(self._FAKE_SLAVE_URL),
-                                                           {'num_executors_already_allocated': 0,
+                                                           {'build_executor_start_index': 0,
                                                             'project_type_params': {
                                                                 'url': 'ssh://{}{}/repos/master/{}'.format(
                                                                     self._fake_hostname,

--- a/test/unit/slave/test_cluster_slave.py
+++ b/test/unit/slave/test_cluster_slave.py
@@ -1,9 +1,10 @@
+import builtins
 from genty import genty, genty_dataset
 import http.client
 import requests
 import requests.models
 from threading import Event
-from unittest.mock import ANY, call, MagicMock, mock_open
+from unittest.mock import ANY, call, MagicMock, Mock, mock_open, patch
 
 from app.project_type.project_type import SetupFailureError
 from app.slave.cluster_slave import BuildTeardownError, ClusterSlave, SlaveState
@@ -114,7 +115,7 @@ class TestClusterSlave(BaseUnitTestCase):
         subjob_done_event, teardown_done_event = self._mock_network_post_and_put(expected_results_api_url,
                                                                                  expected_idle_api_url)
         slave.connect_to_master(self._FAKE_MASTER_URL)
-        slave.setup_build(build_id=123, project_type_params={'type': 'Fake'})
+        slave.setup_build(build_id=123, project_type_params={'type': 'Fake'}, num_executors_already_allocated=0)
         slave.start_working_on_subjob(build_id=123, subjob_id=321,
                                       subjob_artifact_dir='', atomic_commands=[])
         # The timeout for this wait() is arbitrary, but it should be generous so the test isn't flaky on slow machines.
@@ -156,7 +157,7 @@ class TestClusterSlave(BaseUnitTestCase):
         project_type_mock.teardown_build.side_effect = self.no_args_side_effect(teardown_event.wait)
 
         slave.connect_to_master(self._FAKE_MASTER_URL)
-        slave.setup_build(build_id=123, project_type_params={'type': 'Fake'})
+        slave.setup_build(build_id=123, project_type_params={'type': 'Fake'}, num_executors_already_allocated=0)
         self.assertTrue(setup_complete_event.wait(timeout=5), 'Build setup should complete very quickly.')
 
         # Start the first thread that does build teardown. This thread will block on teardown_build().
@@ -184,7 +185,7 @@ class TestClusterSlave(BaseUnitTestCase):
         if not is_setup_successful:
             slave._project_type.fetch_project.side_effect = SetupFailureError
 
-        slave._async_setup_build(executors=[], project_type_params={})
+        slave._async_setup_build(executors=[], project_type_params={}, num_executors_already_allocated=0)
 
         self.mock_network.put_with_digest.assert_called_once_with(
             expected_slave_data_url, request_params={'slave': {'state': expected_slave_state}},
@@ -195,10 +196,27 @@ class TestClusterSlave(BaseUnitTestCase):
         slave.connect_to_master(self._FAKE_MASTER_URL)
         project_type_mock = self.patch('app.slave.cluster_slave.util.create_project_type').return_value
         slave._project_type = project_type_mock
-        slave._async_setup_build([], [])
+        slave._async_setup_build([], {}, 0)
 
-        project_type_mock.fetch_project.assert_called_once_with([], [])
+        project_type_mock.fetch_project.assert_called_once_with()
         self.assertTrue(project_type_mock.run_job_config_setup.called)
+
+    def test_setup_build_sets_base_executor_index(self):
+        slave = self._create_cluster_slave()
+        slave.setup_build(build_id=123, project_type_params={'type': 'Fake'}, num_executors_already_allocated=8)
+        self.assertEqual(8, slave._base_executor_index, 'Build setup should set _base_executor_index')
+
+    def test_execute_subjob_passes_base_executor_index_to_executor(self):
+        slave = self._create_cluster_slave()
+        slave._base_executor_index = 12
+        slave._master_api = Mock()
+        executor = Mock()
+        slave._idle_executors = Mock()
+
+        with patch.object(builtins, 'open', mock_open(read_data='asdf')):
+            slave._execute_subjob(1, 2, executor, '', [])
+
+        executor.execute_subjob.assert_called_with(1, 2, '', [], 12)
 
     def _create_cluster_slave(self, **kwargs):
         """

--- a/test/unit/slave/test_subjob_executor.py
+++ b/test/unit/slave/test_subjob_executor.py
@@ -53,6 +53,7 @@ class TestSubjobExecutor(BaseUnitTestCase):
             'BUILD_EXECUTOR_INDEX': 8
         }
 
-        executor.execute_subjob(1, 2, 'dir', atomic_commands, 6)
+        executor.execute_subjob(build_id=1, subjob_id=2, subjob_artifact_dir='dir', atomic_commands=atomic_commands,
+                                base_executor_index=6)
 
         executor._project_type.execute_command_in_project.assert_called_with('command', expected_env_vars)

--- a/test/unit/slave/test_subjob_executor.py
+++ b/test/unit/slave/test_subjob_executor.py
@@ -1,0 +1,58 @@
+from unittest.mock import Mock
+
+from app.slave.subjob_executor import SubjobExecutor
+from test.framework.base_unit_test_case import BaseUnitTestCase
+
+
+class TestSubjobExecutor(BaseUnitTestCase):
+
+    def test_configure_project_type_passes_project_type_params_and_calls_setup_executor(self):
+        project_type_params = {'test': 'value'}
+        util = self.patch('app.slave.subjob_executor.util')
+        util.create_project_type = Mock(return_value=Mock())
+        executor = SubjobExecutor(1)
+
+        executor.configure_project_type(project_type_params)
+
+        util.create_project_type.assert_called_with(project_type_params)
+        executor._project_type.setup_executor.assert_called_with()
+
+    def test_configure_project_type_with_existing_project_type_calls_teardown(self):
+        executor = SubjobExecutor(1)
+        executor._project_type = Mock()
+        self.patch('app.slave.subjob_executor.util')
+
+        executor.configure_project_type({})
+
+        executor._project_type.teardown_executor.assert_called_once()
+
+    def test_run_job_config_setup_calls_project_types_run_job_config_setup(self):
+        executor = SubjobExecutor(1)
+        executor._project_type = Mock()
+
+        executor.run_job_config_setup()
+
+        executor._project_type.run_job_config_setup.assert_called_with()
+
+    def test_execute_subjob_passes_correct_build_executor_index_to_execute_command_in_project(self):
+        executor = SubjobExecutor(1)
+        executor._project_type = Mock()
+        executor._project_type.execute_command_in_project = Mock(return_value=(1, 2))
+        self.patch('app.slave.subjob_executor.fs_util')
+        self.patch('app.slave.subjob_executor.shutil')
+        os = self.patch('app.slave.subjob_executor.os')
+        os.path = Mock()
+        os.path.join = Mock(return_value='path')
+        atomic_commands = ['command']
+        executor.id = 2
+        expected_env_vars = {
+            'ARTIFACT_DIR': 'path',
+            'ATOM_ID': 0,
+            'EXECUTOR_INDEX': 2,
+            'MACHINE_EXECUTOR_INDEX': 2,
+            'BUILD_EXECUTOR_INDEX': 8
+        }
+
+        executor.execute_subjob(1, 2, 'dir', atomic_commands, 6)
+
+        executor._project_type.execute_command_in_project.assert_called_with('command', expected_env_vars)


### PR DESCRIPTION
There is a use case for functional tests where a set
of logins are generated once, then each test executor
in a build needs to use a login that is not used by
any other executor in the build.

This adds a BUILD_EXEUCTOR_INDEX environment param
which stores a sequential executor id, unique across
the whole build. This can be used to index into a list
of logins created by the user.

Also adds a MACHINE_EXECUTOR_INDEX which is the same as
EXECUTOR_INDEX.

Creating this pull request early (no tests yet) so we can critique the approach.