### PR TITLE
Extend connection error handling

### DIFF
--- a/app/master/slave.py
+++ b/app/master/slave.py
@@ -5,6 +5,7 @@ from app.util.safe_thread import SafeThread
 from app.util.secret import Secret
 from app.util.url_builder import UrlBuilder
 from app.util import util
+import requests.exceptions
 
 
 class Slave(object):
@@ -143,8 +144,7 @@ class Slave(object):
                     self._is_alive = False
                 else:
                     self._is_alive = response_data['slave']['is_alive']
-
-        except ConnectionError:
+        except requests.exceptions.ConnectionError:
             self._logger.warning('Slave with url {} is offline.', self.url)
             self._is_alive = False
 


### PR DESCRIPTION
Here is the stack trace that prompted the change:
 File "/home/jenkins/ClusterRunnerBuild/app/util/safe_thread.py", line 18, in run

    super().run()

  File "/usr/local/lib/python3.4/threading.py", line 868, in run

    self._target(*self._args, **self._kwargs)

  File "/home/jenkins/ClusterRunnerBuild/app/master/slave_allocator.py", line 43, in _slave_allocation_loop

    if not claimed_slave.is_alive(use_cached=False):

  File "/home/jenkins/ClusterRunnerBuild/app/master/slave.py", line 131, in is_alive

    response = self._network.get(self._slave_api.url())

  File "/home/jenkins/ClusterRunnerBuild/app/util/network.py", line 39, in get

    return self._request('GET', *args, **kwargs)

  File "/home/jenkins/ClusterRunnerBuild/app/util/network.py", line 124, in _request

    resp = self._session.request(method, url, data=data_to_send, *args, **kwargs)

  File "/home/jenkins/.virtualenvs/clusterrunner/lib/python3.4/site-packages/requests/sessions.py", line 456, in request

    resp = self.send(prep, **send_kwargs)

  File "/home/jenkins/.virtualenvs/clusterrunner/lib/python3.4/site-packages/requests/sessions.py", line 559, in send

    r = adapter.send(request, **kwargs)

  File "/home/jenkins/.virtualenvs/clusterrunner/lib/python3.4/site-packages/requests/adapters.py", line 375, in send

    raise ConnectionError(e, request=request)

requests.exceptions.ConnectionError: HTTPConnectionPool(host='pod4101-automation1122.pod.box.net', port=43001): Max retries exceeded with url: /v1 (Caused by <class 'ConnectionResetError'>: [Errno 104] Connection reset by peer)
