### PR TITLE
Kill child procs on stop

### DIFF
--- a/test/unit/subcommands/test_stop_subcommand.py
+++ b/test/unit/subcommands/test_stop_subcommand.py
@@ -1,11 +1,14 @@
+import psutil
 import signal
-from unittest.mock import mock_open
+from unittest.mock import mock_open, Mock
 
 from app.subcommands.stop_subcommand import StopSubcommand
 from test.framework.base_unit_test_case import BaseUnitTestCase
 
+NUM_OF_IS_RUNNING_CHECKS_TILL_SIGKILL = 4
 
 class TestStopSubcommand(BaseUnitTestCase):
+
 
     def setUp(self):
         super().setUp()
@@ -49,14 +52,116 @@ class TestStopSubcommand(BaseUnitTestCase):
 
         self.assertFalse(self.os_kill_patch.called)
 
-    def test_stop_subcommand_kills_pid_with_sigterm_if_pid_file_and_pid_exist_and_command_is_whitelisted(self):
+    def setup_environment_for_os_kill(self, main_proc_pid):
         self.os_path_exists_patch.return_value = True
-        self._mock_open(read_data='9999')
+        self._mock_open(read_data=str(main_proc_pid))
         self.psutil_pid_exists_patch.side_effect = [True, False, False]
-        mock_psutil_process = self.patch('psutil.Process').return_value
-        mock_psutil_process.cmdline.return_value = ['python', './main.py', 'master']
+        self.mock_time_so_while_loop_ran_once()
+
+    def mock_time_so_while_loop_ran_once(self):
+        mock_time = self.patch('app.subcommands.stop_subcommand.time')
+        start_time = 0
+        mock_time.time.side_effect = [
+            start_time,
+            start_time + StopSubcommand.SIGTERM_SIGKILL_GRACE_PERIOD_SEC - 1,
+            start_time + StopSubcommand.SIGTERM_SIGKILL_GRACE_PERIOD_SEC + 1]
+
+    def setup_main_and_child_proc(self, main_proc_pid, main_is_running_threshold, child_pid,
+                                  child_is_running_threshold):
+        self.patch('psutil.Process').return_value = self.create_process_mock(
+            pid=main_proc_pid,
+            is_running_threshold=main_is_running_threshold,
+            cmdline=['python', './main.py', 'master'],
+            children=[
+                self.create_process_mock(pid=child_pid, is_running_threshold=child_is_running_threshold)
+            ]
+        )
+
+    def create_process_mock(self, pid, is_running_threshold=None, cmdline=None, children=None):
+        m = Mock(spec_set=psutil.Process)
+        m.pid = pid
+        is_running_threshold = is_running_threshold if is_running_threshold else 0
+        m.is_running.side_effect = [True] * is_running_threshold + [False] * 10000
+        if cmdline:
+            m.cmdline.return_value = cmdline
+
+        m.children.return_value = children if children else []
+        return m
+
+    def test_stop_subcommand_kills_pid_with_sigterm_if_pid_file_and_pid_exist_and_command_is_whitelisted(self):
+        main_proc_pid = 9999
+        threshold = NUM_OF_IS_RUNNING_CHECKS_TILL_SIGKILL - 1
+        child_pid = main_proc_pid + 1
+
+        self.setup_environment_for_os_kill(main_proc_pid)
+        self.setup_main_and_child_proc(main_proc_pid, threshold, child_pid, threshold)
 
         stop_subcommand = StopSubcommand()
         stop_subcommand._kill_pid_in_file_if_exists('/tmp/pid_file_path.pid')
 
-        self.os_kill_patch.assert_called_with(9999, signal.SIGTERM)
+        self.os_kill_patch.assert_called_with(main_proc_pid, signal.SIGTERM)
+        self.assertEquals(2, self.os_kill_patch.call_count)
+
+    def test_stop_subcommand_kills_main_proc_with_sigkill_if_still_running_after_sigterm(self):
+        main_proc_pid = 9999
+        child_proc_pid = main_proc_pid + 1
+        main_threshold = NUM_OF_IS_RUNNING_CHECKS_TILL_SIGKILL
+        child_threshold = NUM_OF_IS_RUNNING_CHECKS_TILL_SIGKILL - 1
+
+        self.setup_environment_for_os_kill(main_proc_pid)
+        self.setup_main_and_child_proc(main_proc_pid,main_threshold, child_proc_pid, child_threshold)
+
+        stop_subcommand = StopSubcommand()
+        stop_subcommand._kill_pid_in_file_if_exists('/tmp/pid_file_path.pid')
+
+        self.os_kill_patch.assert_called_with(main_proc_pid, signal.SIGKILL)
+        self.assertEquals(3, self.os_kill_patch.call_count)
+
+    def test_stop_subcommand_kills_child_proc_with_sigkill_if_still_running_after_sigterm(self):
+        main_proc_pid = 9999
+        main_threshold = NUM_OF_IS_RUNNING_CHECKS_TILL_SIGKILL - 1
+        child_threshold = NUM_OF_IS_RUNNING_CHECKS_TILL_SIGKILL
+        child_pid = main_proc_pid + 1
+
+        self.setup_environment_for_os_kill(main_proc_pid)
+        self.setup_main_and_child_proc(main_proc_pid, main_threshold, child_pid, child_threshold)
+
+        stop_subcommand = StopSubcommand()
+        stop_subcommand._kill_pid_in_file_if_exists('/tmp/pid_file_path.pid')
+
+        self.os_kill_patch.assert_called_with(child_pid, signal.SIGKILL)
+        self.assertEquals(3, self.os_kill_patch.call_count)
+
+    def test_stop_subcommand_kills_proc_with_sigterm(self):
+        main_proc_pid = 9999
+
+        self.setup_environment_for_os_kill(main_proc_pid)
+        self.patch('psutil.Process').return_value = self.create_process_mock(
+            pid=main_proc_pid,
+            is_running_threshold=NUM_OF_IS_RUNNING_CHECKS_TILL_SIGKILL - 1,
+            cmdline=['python', './main.py', 'master'],
+            children=[]
+        )
+
+        stop_subcommand = StopSubcommand()
+        stop_subcommand._kill_pid_in_file_if_exists('/tmp/pid_file_path.pid')
+
+        self.os_kill_patch.assert_called_with(main_proc_pid, signal.SIGTERM)
+        self.assertEquals(1, self.os_kill_patch.call_count)
+
+    def test_stop_subcommand_kills_proc_with_sigkill(self):
+        main_proc_pid = 9999
+
+        self.setup_environment_for_os_kill(main_proc_pid)
+        self.patch('psutil.Process').return_value = self.create_process_mock(
+            pid=main_proc_pid,
+            is_running_threshold=NUM_OF_IS_RUNNING_CHECKS_TILL_SIGKILL,
+            cmdline=['python', './main.py', 'master'],
+            children=[]
+        )
+
+        stop_subcommand = StopSubcommand()
+        stop_subcommand._kill_pid_in_file_if_exists('/tmp/pid_file_path.pid')
+
+        self.os_kill_patch.assert_called_with(main_proc_pid, signal.SIGKILL)
+        self.assertEquals(2, self.os_kill_patch.call_count)


### PR DESCRIPTION
This fixes an issue where child processes are not properly stopped by the stop subcommand.