### PR TITLE
Fix git fetching

### DIFF
--- a/app/master/build.py
+++ b/app/master/build.py
@@ -136,13 +136,7 @@ class Build(object):
         :type slave: Slave
         """
         self._slaves_allocated.append(slave)
-
-        slave.setup(
-            self.build_id(),
-            project_type_params=self.build_request.build_parameters(),
-            build_executor_start_index=self._num_executors_allocated
-        )
-
+        slave.setup(self)
         self._num_executors_allocated += min(slave.num_executors, self._max_executors_per_slave)
 
     def all_subjobs(self):
@@ -323,6 +317,13 @@ class Build(object):
         :rtype: ProjectType
         """
         return self._project_type
+
+    @property
+    def num_executors_allocated(self):
+        """
+        :rtype: int
+        """
+        return self._num_executors_allocated
 
     @property
     def artifacts_archive_file(self):

--- a/app/project_type/git.py
+++ b/app/project_type/git.py
@@ -25,25 +25,6 @@ class Git(ProjectType):
     CLONE_DEPTH = 50
     DIRECTORY_PERMISSIONS = 0o700
 
-    @classmethod
-    def params_for_slave(cls, project_type_params):
-        """
-        Produces a modified set of project type params for use on a slave machine. We modify the repo url so the slave
-        clones or fetches from the master directly. This should be faster than cloning/fetching from the original git
-        remote.
-        :param project_type_params: The parameters for creating an ProjectType instance -- the dict should include the
-            'type' key, which specifies the ProjectType subclass name, and key/value pairs matching constructor
-            arguments for that ProjectType subclass.
-        :type project_type_params: dict
-        :return: A modified set of project type params
-        :rtype: dict
-        """
-        master_repo_path = cls.get_full_repo_directory(project_type_params['url'])
-        master_repo_url = 'ssh://{}{}'.format(Configuration['hostname'], master_repo_path)
-        project_type_params = project_type_params.copy()
-        project_type_params['url'] = master_repo_url
-        return project_type_params
-
     @staticmethod
     def get_full_repo_directory(url):
         """
@@ -77,7 +58,7 @@ class Git(ProjectType):
     # pylint: disable=redefined-builtin
     # Disable "redefined-builtin" because renaming the "hash" parameter would be a breaking change.
     def __init__(self, url, build_project_directory='', project_directory='', remote='origin', branch='master',
-                 hash=None, config=None, job_name=None, remote_files=None):
+                 hash='FETCH_HEAD', config=None, job_name=None, remote_files=None):
         """
         Note: the first line of each parameter docstring will be exposed as command line argument documentation for the
         clusterrunner build client.
@@ -92,7 +73,7 @@ class Git(ProjectType):
         :type remote: str
         :param branch: The git branch name on the remote to fetch
         :type branch: str
-        :param hash: The hash to reset hard on. If both hash and branch are set, we only use the hash.
+        :param hash: The hash to reset hard on. If hash is not set, we use the FETCH_HEAD of <branch>.
         :type hash: str
         :param config: a yaml string representing the project_type's config
         :type config: str|None
@@ -128,6 +109,26 @@ class Git(ProjectType):
         os.symlink(actual_project_directory, build_project_directory)
         self.project_directory = build_project_directory
 
+    def slave_param_overrides(self):
+        """
+        Produce a set of values to override original project type params for use on a slave machine.
+
+        :return: A set of values to override original project type params
+        :rtype: dict[str, str]
+        """
+        param_overrides = super().slave_param_overrides()
+
+        # We modify the repo url so the slave clones or fetches from the master directly. This should be faster than
+        # cloning/fetching from the original git remote.
+        master_repo_url = 'ssh://{}{}'.format(Configuration['hostname'], self._repo_directory)
+        param_overrides['url'] = master_repo_url  # This causes the slave to clone directly from the master.
+
+        # The user-specified branch is overwritten with a locally created ref so that slaves working on a job can
+        # continue to fetch the same HEAD, even if the master resets the user-specified branch for another build.
+        param_overrides['branch'] = self._branch
+
+        return param_overrides
+
     def _fetch_project(self):
         """
         Clones the project if necessary, fetches from the remote repo and resets to the requested commit
@@ -149,25 +150,38 @@ class Git(ProjectType):
 
         # Must add the --update-head-ok in the scenario that the current branch of the working directory
         # is equal to self._branch, otherwise the git fetch will exit with a non-zero exit code.
-        # Must specify the colon in 'branch:branch' so that the branch will be created locally. This is
-        # important because it allows the slave hosts to do a git fetch from the master for this branch.
-        fetch_command = 'git fetch --update-head-ok {0} {1}:{1}'.format(self._remote, self._branch)
+        fetch_command = 'git fetch --update-head-ok {} {}'.format(self._remote, self._branch)
         self._git_remote_command_executor.execute(fetch_command, cwd=self._repo_directory)
 
-        commit_hash = self._hash or 'FETCH_HEAD'
+        # Validate and convert the user-specified hash/refspec to a full git hash
+        self._hash = self._execute_in_repo_and_raise_on_failure(
+            'git rev-parse {}'.format(self._hash),
+            'Could not rev-parse "{}" to a commit hash.'.format(self._hash)
+        ).strip()
+
+        # Save this hash as a local ref. Named local refs are necessary for slaves to fetch correctly from the master.
+        local_ref = 'refs/clusterrunner/' + self._hash
+        update_ref_command = 'git update-ref {} {}'.format(local_ref, self._hash)
+        self._execute_in_repo_and_raise_on_failure(update_ref_command, 'Could not update local ref.')
+        self._branch = local_ref  # this will be passed on to slaves instead of the user-specified branch
 
         # The '--' option acts as a delimiter to differentiate values that can be "tree-ish" or a "path"
-        reset_command = 'git reset --hard {} --'.format(commit_hash)
+        reset_command = 'git reset --hard {} --'.format(self._hash)
         self._execute_in_repo_and_raise_on_failure(reset_command, 'Could not reset Git repo.')
 
         self._execute_in_repo_and_raise_on_failure('git clean -dfx', 'Could not clean Git repo.')
 
     def _execute_in_repo_and_raise_on_failure(self, command, message):
-        self._execute_and_raise_on_failure(command, message, self._repo_directory)
+        """
+        :rtype: string
+        """
+        return self._execute_and_raise_on_failure(command, message, self._repo_directory)
 
     def execute_command_in_project(self, *args, **kwargs):
         """
         Execute a command inside the repo. See superclass for parameter documentation.
+
+        :rtype: (string, int)
         """
         # There is a scenario where self.project_directory doesn't exist yet (when a certain repo has never been
         # fetched before on this particular machine). In order to avoid having python barf during this scenario,

--- a/app/util/util.py
+++ b/app/util/util.py
@@ -53,16 +53,3 @@ def create_project_type(project_type_params):
 
     # Not yet implemented other project types
     return None
-
-
-def project_type_params_for_slave(project_type_params):
-    """
-    :param project_type_params: The parameters for creating an ProjectType instance -- the dict should include the
-        'type' key, which specifies the ProjectType subclass name, and key/value pairs matching constructor arguments
-        for that ProjectType subclass.
-    :type project_type_params: dict
-    :return: A modified set of project type params
-    :rtype: dict [str, str]
-    """
-    project_type_class = get_project_type_subclass(project_type_params['type'])
-    return project_type_class.params_for_slave(project_type_params)

--- a/test/unit/master/test_build.py
+++ b/test/unit/master/test_build.py
@@ -26,22 +26,16 @@ class TestBuild(BaseUnitTestCase):
         self.mock_fs = mock_util.fs
 
     def test_allocate_slave_calls_slave_setup(self):
-        # arrange
         subjobs = self._create_subjobs()
-
         mock_project_type = self._create_mock_project_type()
-        fake_setup_command = 'docker pull my:leg'
         mock_slave = self._create_mock_slave()
-
-        # act
-        build = Build(BuildRequest({'setup': fake_setup_command}))
+        build = Build(Mock(spec_set=BuildRequest))
         build._project_type = mock_project_type
+
         build.prepare(subjobs, self._create_job_config())
         build.allocate_slave(mock_slave)
 
-        # assert
-        mock_slave.setup.assert_called_once_with(build.build_id(), build_executor_start_index=0,
-                                                 project_type_params={'setup': fake_setup_command})
+        mock_slave.setup.assert_called_once_with(build)
 
     def test_build_doesnt_use_more_than_max_executors(self):
         subjobs = self._create_subjobs()

--- a/test/unit/project_type/test_git.py
+++ b/test/unit/project_type/test_git.py
@@ -1,4 +1,6 @@
+from subprocess import Popen
 from unittest.mock import ANY, Mock, MagicMock
+
 import pexpect
 import re
 
@@ -17,8 +19,6 @@ class TestGit(BaseUnitTestCase):
         self.mock_pexpect_child = self.patch('pexpect.spawn').return_value
         self.mock_pexpect_child.before = 'None'
         self.mock_pexpect_child.exitstatus = 0
-        mock_tempfile = self.patch('app.project_type.project_type.TemporaryFile').return_value
-        mock_tempfile.read.return_value = b'fake file contents'
 
     def test_timing_file_path_happy_path(self):
         git_env = Git("ssh://scm.dev.box.net/box/www/current", 'origin', 'refs/changes/78/151978/27')
@@ -32,8 +32,7 @@ class TestGit(BaseUnitTestCase):
     def test_execute_command_in_project_specifies_cwd_if_exists(self):
         os_path_exists_patch = self.patch('os.path.exists')
         os_path_exists_patch.return_value = True
-        project_type_popen_patch = self.patch('app.project_type.project_type.Popen')
-        project_type_popen_patch.return_value.returncode = 0
+        project_type_popen_patch = self._patch_popen()
 
         git_env = Git("ssh://scm.dev.box.net/box/www/current", 'origin', 'refs/changes/78/151978/27')
         git_env.project_directory = 'proj_dir'
@@ -50,8 +49,7 @@ class TestGit(BaseUnitTestCase):
     def test_execute_command_in_project_type_specifies_cwd_if_doesnt_exist(self):
         os_path_exists_patch = self.patch('os.path.exists')
         os_path_exists_patch.return_value = False
-        project_type_popen_patch = self.patch('app.project_type.project_type.Popen')
-        project_type_popen_patch.return_value.returncode = 0
+        project_type_popen_patch = self._patch_popen()
 
         git_env = Git("ssh://scm.dev.box.net/box/www/current", 'origin', 'refs/changes/78/151978/27')
         git_env.project_directory = 'proj_dir'
@@ -147,8 +145,8 @@ class TestGit(BaseUnitTestCase):
         mock_rmtree = self.patch('shutil.rmtree')
 
         git = Git('url')
-        git._repo_directory = 'repo_path'
-        git._execute_and_raise_on_failure = Mock()
+        git._repo_directory = 'fake/repo_path'
+        git._execute_and_raise_on_failure = MagicMock()
         git.execute_command_in_project = Mock(return_value=('', 0))
 
         mock_fs.create_dir.call_count = 0  # only measure calls made in _fetch_project
@@ -156,8 +154,8 @@ class TestGit(BaseUnitTestCase):
 
         git._fetch_project()
 
-        self.assertEqual(mock_fs.create_dir.call_count, 1)
-        self.assertEqual(mock_rmtree.call_count, 1)
+        mock_rmtree.assert_called_once_with('fake/repo_path')
+        mock_fs.create_dir.assert_called_once_with('fake/repo_path', Git.DIRECTORY_PERMISSIONS)
 
     def test_password_prompt_is_covered_by_pexpect_regexes(self):
         git_executor = _GitRemoteCommandExecutor()
@@ -187,3 +185,56 @@ class TestGit(BaseUnitTestCase):
 
         with self.assertRaises(BrokenPipeError):
             git_executor.execute('fake command', cwd=None, timeout=0, num_tries=3)
+
+    def test_slave_param_overrides_returns_expected(self):
+        self._patch_popen({
+            'git rev-parse FETCH_HEAD': _FakePopenResult(stdout='deadbee123\n')
+        })
+        self.patch('app.project_type.git.os.path.exists').return_value = False
+        self.patch('app.project_type.git.os.path.isfile').return_value = False
+        self.patch('app.project_type.git._GitRemoteCommandExecutor')
+        Configuration['repo_directory'] = '/repo-directory'
+
+        git = Git(url='http://original-user-specified-url.test/repo-path/repo-name')
+        git.fetch_project()
+        actual_overrides = git.slave_param_overrides()
+
+        expected_overrides = {
+            'url': 'ssh://fake_hostname/repodirectory/originaluserspecifiedurl.test/repopath/reponame',
+            'branch': 'refs/clusterrunner/deadbee123',
+        }
+        self.assertEqual(expected_overrides, actual_overrides, 'Slave param overrides from Git object should match'
+                                                               'expected.')
+
+    def _patch_popen(self, command_to_result_map=None):
+        """
+        Mock out calls to Popen to inject fake results for specific command strings.
+
+        :param command_to_result_map: A dict that maps a command string regex to a _FakePopenResult object
+        :type command_to_result_map: dict[str, _FakePopenResult]
+        :return: The patched popen constructor mock
+        :rtype: MagicMock
+        """
+        command_to_result_map = command_to_result_map or {}
+        self.patch('app.project_type.project_type.TemporaryFile', new=lambda: Mock())
+        project_type_popen_patch = self.patch('app.project_type.project_type.Popen')
+
+        def fake_popen_constructor(command, stdout, stderr, *args, **kwargs):
+            fake_result = _FakePopenResult()  # default value
+            for command_regex in command_to_result_map:
+                if re.search(command_regex, command):
+                    fake_result = command_to_result_map[command_regex]
+                    break
+            stdout.read.return_value = fake_result.stdout.encode()
+            stderr.read.return_value = fake_result.stderr.encode()
+            return Mock(spec=Popen, returncode=fake_result.return_code)
+
+        project_type_popen_patch.side_effect = fake_popen_constructor
+        return project_type_popen_patch
+
+
+class _FakePopenResult:
+    def __init__(self, return_code=0, stdout='', stderr=''):
+        self.return_code = return_code
+        self.stdout = stdout
+        self.stderr = stderr


### PR DESCRIPTION
There is a race condition right now where if a git branch is specified
in a build request, slaves will pull from the master using that branch
name (whose head may change when the master handles future builds).

This change creates a local ref on the master whenever a git build is
requested. This ref is then passed to the slaves instead of the user-
specified branch name so that the slaves are guaranteed to always fetch
the same commit.

As part of this change, I also refactored how the slave build parameter
overriding works.

This will fix #103.