### PR TITLE
Fix slave stuck on subjob completion error

### DIFF
--- a/app/master/build.py
+++ b/app/master/build.py
@@ -176,12 +176,12 @@ class Build(object):
                 break
             slave.claim_executor()
             self._num_executors_in_use += 1
-            self.execute_next_subjob_on_slave(slave)
+            self.execute_next_subjob_or_teardown_slave(slave)
 
-    def execute_next_subjob_on_slave(self, slave):
+    def execute_next_subjob_or_teardown_slave(self, slave):
         """
         Grabs an unstarted subjob off the queue and sends it to the specified slave to be executed. If the unstarted
-        subjob queue is empty, we mark the slave as idle.
+        subjob queue is empty, we teardown the slave to free it up for other builds.
 
         :type slave: Slave
         """
@@ -207,8 +207,14 @@ class Build(object):
         :type subjob_id: int
         :type payload: dict
         """
-        self._handle_subjob_payload(subjob_id, payload)
-        self._mark_subjob_complete(subjob_id)
+        try:
+            self._handle_subjob_payload(subjob_id, payload)
+            self._mark_subjob_complete(subjob_id)
+
+        except Exception:
+            self._logger.exception('Error while completing subjob; marking build as failed.')
+            self.mark_failed('Error occurred while completing subjob {}.'.format(subjob_id))
+            raise
 
     def _handle_subjob_payload(self, subjob_id, payload):
         if not payload:

--- a/app/master/cluster_master.py
+++ b/app/master/cluster_master.py
@@ -199,7 +199,7 @@ class ClusterMaster(object):
             required_params = build_request.required_parameters()
             response = {'error': 'Missing required parameter. Required parameters: {}'.format(required_params)}
 
-        return success, response
+        return success, response  # todo: refactor to use exception instead of boolean
 
     def handle_request_to_update_build(self, build_id, update_params):
         """
@@ -234,8 +234,10 @@ class ClusterMaster(object):
         slave = self._all_slaves_by_url[slave_url]
         # If the build has been canceled, don't work on the next subjob.
         if not build.is_finished:
-            build.complete_subjob(subjob_id, payload)
-            build.execute_next_subjob_on_slave(slave)
+            try:
+                build.complete_subjob(subjob_id, payload)
+            finally:
+                build.execute_next_subjob_or_teardown_slave(slave)
 
     def get_build(self, build_id):
         """

--- a/test/framework/base_unit_test_case.py
+++ b/test/framework/base_unit_test_case.py
@@ -124,6 +124,17 @@ class BaseUnitTestCase(TestCase):
         self._patched_items[mock] = patcher, allow_repatch
         return mock
 
+    def patch_object(self, target, attribute, **kwargs):
+        """
+        Replace the named attribute on the given object with a mock.
+
+        :type target: object
+        :type attribute: str
+        :rtype: MagicMock
+        """
+        patcher = patch.object(target, attribute, **kwargs)
+        return patcher.start()
+
     def unpatch(self, target):
         """
         Unpatch the specified target, restoring the original method or value. This is useful when something has already


### PR DESCRIPTION
This addresses an issue in which any error raised during subjob
completion (e.g., results tar file creation fails) would cause the
slave and build to hang indefinitely.

This change combined with #100 should fix #98.