### PR TITLE
Small doc tweaks

### DIFF
--- a/_docs/installation.md
+++ b/_docs/installation.md
@@ -28,6 +28,7 @@ Pick a set of instructions based on your operating system.
 We suggest you add an alias for the clusterrunner binary to your shell startup file in order to easily execute ClusterRunner.
 
 {% highlight bash %}
+# Add this line to your ~/.bash_profile:
 ~ $ alias clusterrunner='~/.clusterrunner/dist/clusterrunner'
 {% endhighlight %}
 

--- a/_docs/quickstart.md
+++ b/_docs/quickstart.md
@@ -18,7 +18,7 @@ The easiest way to try out ClusterRunner is on a single machine - with a master 
 
 {% highlight bash %}
 # Grab the demo project
-~ $ git clone git@github.com:boxengservices/ClusterRunnerDemo.git ~/ClusterRunnerDemo/
+~ $ git clone https://github.com/boxengservices/ClusterRunnerDemo.git ~/ClusterRunnerDemo/
 ~ $ cd ~/ClusterRunnerDemo
 
 # Run the tests for our "Simple" job


### PR DESCRIPTION
- Change the ClusterRunner demo project clone command to use https
instead of ssh since it was failing for some people.
- Add a comment to the bash alias section of the install instructions
to make it more clear that you're supposed to add it to your bash init.