### PR TITLE
Fix command line help for frozen app

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ buildOptions = {
     'create_shared_zip': True,
     'include_in_shared_zip': True,
     'include_files': [('conf/default_clusterrunner.conf', 'conf/default_clusterrunner.conf')],
-    'optimize': 2,
+    'optimize': 1,  # This should not be set to 2 because that removes docstrings needed for command line help.
 }
 
 base = 'Console'


### PR DESCRIPTION
Our dynamically generated help strings for the build subcommand were
not being correctly displayed in the frozen application. The reason is
that the help strings are generated from docstrings which are removed
during freeze.