### PR TITLE
Add atom timings to API response

### DIFF
--- a/app/master/atom.py
+++ b/app/master/atom.py
@@ -1,0 +1,16 @@
+
+class Atom(object):
+    def __init__(self, env_var_name, atom_value, expected_time=None, actual_time=None):
+        """
+        :type env_var_name: str
+        :type atom_value: str
+        :type expected_time: float
+        :type actual_time: float
+        """
+        self._env_var_name = env_var_name
+        self._atom_value = atom_value
+        self.expected_time = expected_time
+        self.actual_time = actual_time
+
+        # Convert atomizer command output into environment variable export commands.
+        self.command_string = 'export {}="{}";'.format(self._env_var_name, self._atom_value)

--- a/app/master/atom_grouper.py
+++ b/app/master/atom_grouper.py
@@ -2,7 +2,7 @@ class AtomGrouper(object):
     def __init__(self, atoms, max_processes):
         """
         :param atoms: the list of atoms
-        :type atoms: list
+        :type atoms: list[app.master.atom.Atom]
         :param max_processes: the maximum number of processes requested for this job
         :type max_processes: int
         """
@@ -16,11 +16,6 @@ class AtomGrouper(object):
         For now we are going with the default implementation, which is one atom per grouping.
 
         :return: a list of lists of atoms
-        :rtype: list[list[str]]
+        :rtype: list[list[app.master.atom.Atom]]
         """
-        groupings = []
-
-        for atom in self._atoms:
-            groupings.append([atom])
-
-        return groupings
+        return [[atom] for atom in self._atoms]

--- a/app/master/atomizer.py
+++ b/app/master/atomizer.py
@@ -1,3 +1,4 @@
+from app.master.atom import Atom
 from app.util import log
 
 
@@ -23,7 +24,7 @@ class Atomizer(object):
         :param project_type: The ProjectType instance in which to execute the atomizer commands
         :type project_type: ProjectType
         :return: The list of environment variable "export" atom commands
-        :rtype: list[str]
+        :rtype: list[app.master.atom.Atom]
         """
         atoms_list = []
         for atomizer_dict in self._atomizer_dicts:
@@ -34,8 +35,7 @@ class Atomizer(object):
                                        '\n{}', atomizer_command, atomizer_var_name, exit_code, atomizer_output)
                     raise AtomizerError('Atomizer command failed!')
 
-                # Convert atomizer command output into environment variable export commands.
-                new_atoms = ['export {}="{}";'.format(atomizer_var_name, atom_value)
+                new_atoms = [Atom(atomizer_var_name, atom_value)
                              for atom_value in atomizer_output.strip().splitlines()]
                 atoms_list.extend(new_atoms)
 

--- a/app/master/build_request_handler.py
+++ b/app/master/build_request_handler.py
@@ -173,14 +173,14 @@ class BuildRequestHandler(object):
         If not, use the default AtomGrouper (groups each atom into its own subjob).
 
         :param atoms: all of the atoms to be run this time
-        :type atoms: list[str]
+        :type atoms: list[app.master.atom.Atom]
         :param max_executors: the maximum number of executors for this build
         :type max_executors: int
         :param timing_file_path: path to where the timing data file would be stored (if it exists) for this job
         :type timing_file_path: str
         :type project_directory: str
         :return: the grouped atoms (in the form of list of lists of strings)
-        :rtype: list[list[str]]
+        :rtype: list[list[app.master.atom.Atom]]
         """
         atom_time_map = None
 

--- a/app/master/time_based_atom_grouper.py
+++ b/app/master/time_based_atom_grouper.py
@@ -1,5 +1,4 @@
 from collections import OrderedDict
-from operator import itemgetter
 
 from app.master.atom_grouper import AtomGrouper
 
@@ -57,7 +56,7 @@ class TimeBasedAtomGrouper(object):
     def __init__(self, atoms, max_executors, atom_time_map, project_directory):
         """
         :param atoms: the list of atoms for this build
-        :type atoms: list[str]
+        :type atoms: list[app.master.atom.Atom]
         :param max_executors: the maximum number of executors for this build
         :type max_executors: int
         :param atom_time_map: a dictionary containing the historic times for atoms for this particular job
@@ -74,18 +73,19 @@ class TimeBasedAtomGrouper(object):
         Group the atoms into subjobs using historic timing data.
 
         :return: a list of lists of atoms
-        :rtype: list[list[str]]
+        :rtype: list[list[app.master.atom.Atom]]
         """
         # 1). Coalesce the atoms with historic atom times, and also get total estimated runtime
         try:
-            new_atoms_with_times_list, total_estimated_runtime \
-                = self._coalesce_new_atoms_with_historic_times(self._atoms, self._atom_time_map, self._project_directory)
+            total_estimated_runtime = self._set_expected_atom_times(
+                self._atoms, self._atom_time_map, self._project_directory)
         except _AtomTimingDataError:
             grouper = AtomGrouper(self._atoms, self._max_executors)
             return grouper.groupings()
 
-        # 2). Sort them by time, and add them to an OrderedDict
-        sorted_atom_times_left = OrderedDict(sorted(new_atoms_with_times_list, key=itemgetter(1), reverse=True))
+        # 2). Sort them by decreasing time, and add them to an OrderedDict
+        atoms_by_decreasing_time = sorted(self._atoms, key=lambda atom: atom.expected_time, reverse=True)
+        sorted_atom_times_left = OrderedDict([(atom, atom.expected_time) for atom in atoms_by_decreasing_time])
 
         # 3). Group them!
 
@@ -100,31 +100,29 @@ class TimeBasedAtomGrouper(object):
         subjobs.extend(small_subjobs)
         return subjobs
 
-    def _coalesce_new_atoms_with_historic_times(self, new_atoms, old_atoms_with_times, project_directory):
+    def _set_expected_atom_times(self, new_atoms, old_atoms_with_times, project_directory):
         """
-        Combine the historic timing data from previous atoms (for the same job) with the new atoms generated for this
-        job.
+        Set the expected runtime (new_atom.expected_time) of each atom in new_atoms using historic timing data.
 
         Additionally, return the total estimated serial-runtime for this build. Although this seems like an odd thing
         for this method to return, it is done here for efficiency. There can be thousands of atoms, and iterating
         through them multiple times seems inefficient.
 
         :param new_atoms: the list of atoms that will be run in this build
-        :type new_atoms: list[str]
+        :type new_atoms: list[app.master.atom.Atom]
         :param old_atoms_with_times: a dictionary containing the historic times for atoms for this particular job
         :type old_atoms_with_times: dict[str, float]
         :type project_directory: str
-        :return: the coalesced new atoms with timing data in a list, the total estimated runtime in seconds
-        :rtype: list[list[str, float]], float
+        :return: the total estimated runtime in seconds
+        :rtype: float
         """
-        coalesced_atoms_with_times = []
         atoms_without_timing_data = []
         total_time = 0
         max_atom_time = 0
 
         # Generate list for atoms that have timing data
         for new_atom in new_atoms:
-            new_atom_directory_stripped = new_atom.replace(project_directory, '')
+            new_atom_directory_stripped = new_atom.command_string.replace(project_directory, '')
 
             # When matching up new atoms with stored atom timing data, we use the project-directory-stripped
             # atom string for matching.
@@ -132,26 +130,25 @@ class TimeBasedAtomGrouper(object):
                 atoms_without_timing_data.append(new_atom)
                 continue
 
-            atom_time = old_atoms_with_times[new_atom_directory_stripped]
+            new_atom.expected_time = old_atoms_with_times[new_atom_directory_stripped]
 
             # Discover largest single atom time to use as conservative estimates for atoms with unknown times
-            if max_atom_time < atom_time:
-                max_atom_time = atom_time
+            if max_atom_time < new_atom.expected_time:
+                max_atom_time = new_atom.expected_time
 
             # We want to return the atom with the project directory still in it, as this data will directly be
             # sent to the slave to be run.
-            coalesced_atoms_with_times.append([new_atom, atom_time])
-            total_time += atom_time
+            total_time += new_atom.expected_time
 
         # For the atoms without historic timing data, assign them the largest atom time we have
         for new_atom in atoms_without_timing_data:
-            coalesced_atoms_with_times.append([new_atom, max_atom_time])
+            new_atom.expected_time = max_atom_time
 
         if len(new_atoms) == len(atoms_without_timing_data):
             raise _AtomTimingDataError
 
         total_time += (max_atom_time * len(atoms_without_timing_data))
-        return coalesced_atoms_with_times, total_time
+        return total_time
 
     def _group_atoms_into_sized_buckets(self, sorted_atom_time_dict, target_group_time, max_groups_to_create):
         """
@@ -165,7 +162,7 @@ class TimeBasedAtomGrouper(object):
 
         :param sorted_atom_time_dict: the sorted (longest first), double-ended queue containing [atom, time] pairs.
             This OrderedDict will have elements removed from this method.
-        :type sorted_atom_time_dict: OrderedDict[list[string, float]]
+        :type sorted_atom_time_dict: OrderedDict[app.master.atom.Atom, float]
         :param target_group_time: how long each subjob should approximately take
         :type target_group_time: float
         :param max_groups_to_create: the maximum number of subjobs to create. Once max_groups_to_create limit is
@@ -173,7 +170,7 @@ class TimeBasedAtomGrouper(object):
             is no limit.
         :type max_groups_to_create: int|None
         :return: the groups of grouped atoms, with each group taking an estimated target_group_time
-        :rtype: list[list[str]]
+        :rtype: list[list[app.master.atom.Atom]]
         """
         subjobs = []
         subjob_time_so_far = 0

--- a/test/unit/master/test_atomizer.py
+++ b/test/unit/master/test_atomizer.py
@@ -18,11 +18,13 @@ class TestAtomizer(BaseUnitTestCase):
 
         atomizer = Atomizer([{'TEST_FILE': _FAKE_ATOMIZER_COMMAND}])
         actual_atoms = atomizer.atomize_in_project(mock_project)
+        actual_atom_commands = [atom.command_string for atom in actual_atoms]
 
-        expected_atoms = ['export TEST_FILE="./test_a.py";',
-                          'export TEST_FILE="./test_b.py";',
-                          'export TEST_FILE="./test_c.py";']
-        self.assertListEqual(expected_atoms, actual_atoms, 'List of actual atoms should match list of expected atoms.')
+        expected_atom_commands = ['export TEST_FILE="./test_a.py";',
+                                  'export TEST_FILE="./test_b.py";',
+                                  'export TEST_FILE="./test_c.py";']
+        self.assertListEqual(expected_atom_commands, actual_atom_commands,
+                             'List of actual atoms should match list of expected atoms.')
         mock_project.execute_command_in_project.assert_called_once_with(_FAKE_ATOMIZER_COMMAND)
 
     def test_atomizer_raises_exception_when_atomize_command_fails(self):

--- a/test/unit/master/test_subjob.py
+++ b/test/unit/master/test_subjob.py
@@ -1,0 +1,35 @@
+from unittest.mock import Mock
+from app.master.atom import Atom
+from app.master.job_config import JobConfig
+
+from app.master.subjob import Subjob
+from app.project_type.project_type import ProjectType
+from test.framework.base_unit_test_case import BaseUnitTestCase
+
+
+class TestSubjob(BaseUnitTestCase):
+
+    def test_api_representation_matches_expected(self):
+        job_config_command = 'fake command'
+        subjob = Subjob(
+            build_id=12,
+            subjob_id=34,
+            project_type=Mock(spec_set=ProjectType),
+            job_config=Mock(spec=JobConfig, command=job_config_command),
+            atoms=[
+                Atom('BREAKFAST', 'pancakes', expected_time=23.4, actual_time=56.7),
+                Atom('BREAKFAST', 'cereal', expected_time=89.0, actual_time=24.6),
+            ],
+        )
+
+        actual_api_repr = subjob.api_representation()
+
+        expected_api_repr = {
+            'id': 34,
+            'command': job_config_command,
+            'atoms': [
+                {'id': 0, 'atom': 'export BREAKFAST="pancakes";', 'expected_time': 23.4, 'actual_time': 56.7},
+                {'id': 1, 'atom': 'export BREAKFAST="cereal";', 'expected_time': 89.0, 'actual_time': 24.6},
+            ]
+        }
+        self.assertEqual(actual_api_repr, expected_api_repr, 'Actual api representation should match expected.')

--- a/test/unit/master/test_time_based_atom_grouper.py
+++ b/test/unit/master/test_time_based_atom_grouper.py
@@ -1,47 +1,53 @@
+from unittest.mock import Mock
+from app.master.atom import Atom
 from app.master.time_based_atom_grouper import TimeBasedAtomGrouper, _AtomTimingDataError
 from test.framework.base_unit_test_case import BaseUnitTestCase
 
 
 class TestTimeBasedAtomGrouper(BaseUnitTestCase):
+    def _mock_atoms(self, command_strings):
+        atom_spec = Atom('key', 'val')
+        return [Mock(spec_set=atom_spec, command_string=cmd) for cmd in command_strings]
+
     def test_coalesce_new_atoms_with_no_atom_times(self):
-        new_atoms = ['atom_1', 'atom_2', 'atom_3']
-        old_atoms_with_times = dict()
+        new_atoms = self._mock_atoms(['atom_1', 'atom_2', 'atom_3'])
+        old_atoms_with_times = {}
         project_directory = 'some_project_directory'
 
         atom_grouper = TimeBasedAtomGrouper(new_atoms, 3, old_atoms_with_times, project_directory)
 
         with self.assertRaises(_AtomTimingDataError):
-            atom_grouper._coalesce_new_atoms_with_historic_times(new_atoms, old_atoms_with_times, project_directory)
+            atom_grouper._set_expected_atom_times(new_atoms, old_atoms_with_times, project_directory)
 
     def test_coalesce_new_atoms_with_all_atom_times(self):
-        new_atoms = ['atom_1', 'atom_2', 'atom_3']
-        old_atoms_with_times = dict({'atom_1': 1.0, 'atom_2': 2.0, 'atom_3': 3.0})
+        new_atoms = self._mock_atoms(['atom_1', 'atom_2', 'atom_3'])
+        old_atoms_with_times = {'atom_1': 1.0, 'atom_2': 2.0, 'atom_3': 3.0}
         expected_contents = {'atom_1': 1.0, 'atom_2': 2.0, 'atom_3': 3.0}
 
         atom_grouper = TimeBasedAtomGrouper(new_atoms, 3, old_atoms_with_times, 'some_project_directory')
-        groups, total_time = atom_grouper._coalesce_new_atoms_with_historic_times(new_atoms, old_atoms_with_times, 'some_project_directory')
+        total_time = atom_grouper._set_expected_atom_times(new_atoms, old_atoms_with_times, 'some_project_directory')
 
         self.assertEquals(total_time, 6.0)
-        self._assert_coalesced_contents(groups, expected_contents)
+        self._assert_coalesced_contents(new_atoms, expected_contents)
 
     def test_coalesce_new_atoms_with_some_atom_times(self):
-        new_atoms = ['atom_2', 'atom_3', 'atom_4', 'atom_5']
-        old_atoms_with_times = dict({'atom_1': 1.0, 'atom_2': 2.0, 'atom_3': 3.0})
+        new_atoms = self._mock_atoms(['atom_2', 'atom_3', 'atom_4', 'atom_5'])
+        old_atoms_with_times = {'atom_1': 1.0, 'atom_2': 2.0, 'atom_3': 3.0}
         expected_contents = {'atom_2': 2.0, 'atom_3': 3.0, 'atom_4': 3.0, 'atom_5': 3.0}
 
         atom_grouper = TimeBasedAtomGrouper(new_atoms, 3, old_atoms_with_times, 'some_project_directory')
-        groups, total_time = atom_grouper._coalesce_new_atoms_with_historic_times(new_atoms, old_atoms_with_times, 'some_project_directory')
+        total_time = atom_grouper._set_expected_atom_times(new_atoms, old_atoms_with_times, 'some_project_directory')
 
         self.assertEquals(total_time, 11.0)
-        self._assert_coalesced_contents(groups, expected_contents)
+        self._assert_coalesced_contents(new_atoms, expected_contents)
 
     def test_groupings_data_set_1(self):
-        new_atoms = [
-            'atom_1', 'atom_2', 'atom_3', 'atom_4', 'atom_5', 'atom_6', 'atom_7', 'atom_8', 'atom_9', 'atom_10']
-        old_atoms_with_times = dict({
+        new_atoms = self._mock_atoms([
+            'atom_1', 'atom_2', 'atom_3', 'atom_4', 'atom_5', 'atom_6', 'atom_7', 'atom_8', 'atom_9', 'atom_10'])
+        old_atoms_with_times = {
             'atom_1': 1.0, 'atom_2': 10.0, 'atom_3': 11.0, 'atom_4': 2.0, 'atom_5': 10.0, 'atom_6': 5.0,
             'atom_7': 2.0, 'atom_8': 8.0, 'atom_9': 10.0, 'atom_10': 3.0
-        })
+        }
         expected_groupings = [
             ['atom_2', 'atom_3', 'atom_10'],
             ['atom_4', 'atom_5', 'atom_7', 'atom_9'],
@@ -53,10 +59,10 @@ class TestTimeBasedAtomGrouper(BaseUnitTestCase):
         atom_grouper = TimeBasedAtomGrouper(new_atoms, 2, old_atoms_with_times, 'some_project_directory')
         subjobs = atom_grouper.groupings()
 
-        self._assert_groupings_equal(expected_groupings, subjobs)
+        self._assert_subjobs_match_expected_groupings(subjobs, expected_groupings)
 
     def test_grouping_makes_atoms_with_no_timing_as_separate_subjobs(self):
-        new_atoms = ['atom_0', 'atom_1']
+        new_atoms = self._mock_atoms(['atom_0', 'atom_1'])
         old_atoms_with_times = {}
         expected_number_of_subjobs = 2
 
@@ -68,10 +74,7 @@ class TestTimeBasedAtomGrouper(BaseUnitTestCase):
     def test_grouping_defaults_to_atom_grouper_when_no_timing_data_exists(self):
         num_atoms = 1000
         max_executors = 2
-        new_atoms = []
-
-        for i in range(num_atoms):
-            new_atoms.append('atom_' + str(i))
+        new_atoms = self._mock_atoms(['atom_{}'.format(i) for i in range(num_atoms)])
         old_atoms_with_times = {}
 
         atom_grouper = TimeBasedAtomGrouper(new_atoms, max_executors, old_atoms_with_times, 'some_project_directory')
@@ -80,48 +83,48 @@ class TestTimeBasedAtomGrouper(BaseUnitTestCase):
         self.assertEquals(num_atoms, len(subjobs))
 
     def test_groupings_data_set_2(self):
-        new_atoms = ['atom_1', 'atom_2', 'atom_3', 'atom_4', 'atom_5']
-        old_atoms_with_times = dict({
+        new_atoms = self._mock_atoms(['atom_1', 'atom_2', 'atom_3', 'atom_4', 'atom_5'])
+        old_atoms_with_times = {
             'atom_1': 100.0, 'atom_2': 100.0, 'atom_3': 50.0, 'atom_4': 2.0, 'atom_5': 2.0
-        })
+        }
         expected_groupings = [['atom_1'], ['atom_2'], ['atom_3', 'atom_4', 'atom_5']]
 
         atom_grouper = TimeBasedAtomGrouper(new_atoms, 3, old_atoms_with_times, 'some_project_directory')
         subjobs = atom_grouper.groupings()
 
-        self._assert_groupings_equal(expected_groupings, subjobs)
+        self._assert_subjobs_match_expected_groupings(subjobs, expected_groupings)
 
     def test_groupings_data_set_3(self):
-        new_atoms = ['atom_1', 'atom_2', 'atom_3', 'atom_4', 'atom_5']
-        old_atoms_with_times = dict({
+        new_atoms = self._mock_atoms(['atom_1', 'atom_2', 'atom_3', 'atom_4', 'atom_5'])
+        old_atoms_with_times = {
             'atom_1': 100.0, 'atom_2': 100.0, 'atom_3': 50.0, 'atom_4': 2.0, 'atom_5': 2.0
-        })
+        }
         expected_groupings = [['atom_1'], ['atom_2'], ['atom_3'], ['atom_4', 'atom_5']]
 
         atom_grouper = TimeBasedAtomGrouper(new_atoms, 2, old_atoms_with_times, 'some_project_directory')
         subjobs = atom_grouper.groupings()
 
-        self._assert_groupings_equal(expected_groupings, subjobs)
+        self._assert_subjobs_match_expected_groupings(subjobs, expected_groupings)
 
     def test_groupings_data_set_4(self):
-        new_atoms = ['atom_1', 'atom_2', 'atom_3', 'atom_4', 'atom_5']
-        old_atoms_with_times = dict({
+        new_atoms = self._mock_atoms(['atom_1', 'atom_2', 'atom_3', 'atom_4', 'atom_5'])
+        old_atoms_with_times = {
             'atom_1': 100.0, 'atom_2': 100.0, 'atom_3': 50.0, 'atom_4': 2.0, 'atom_5': 2.0
-        })
+        }
         expected_groupings = [['atom_1'], ['atom_2'], ['atom_3'], ['atom_4'], ['atom_5']]
 
         atom_grouper = TimeBasedAtomGrouper(new_atoms, 5, old_atoms_with_times, 'some_project_directory')
         subjobs = atom_grouper.groupings()
 
-        self._assert_groupings_equal(expected_groupings, subjobs)
+        self._assert_subjobs_match_expected_groupings(subjobs, expected_groupings)
 
     def test_groupings_maintains_project_directory_in_returned_atoms(self):
-        new_atoms = [
+        new_atoms = self._mock_atoms([
             '/var/clusterrunner/repos/scm/atom_1',
             '/var/clusterrunner/repos/scm/atom_2',
             '/var/clusterrunner/repos/scm/atom_3'
-        ]
-        old_atoms_with_times = dict({'atom_1': 100.0, 'atom_2': 100.0, 'atom_3': 100.0})
+        ])
+        old_atoms_with_times = {'atom_1': 100.0, 'atom_2': 100.0, 'atom_3': 100.0}
         expected_groupings = [
             ['/var/clusterrunner/repos/scm/atom_1'],
             ['/var/clusterrunner/repos/scm/atom_2'],
@@ -130,36 +133,35 @@ class TestTimeBasedAtomGrouper(BaseUnitTestCase):
         atom_grouper = TimeBasedAtomGrouper(new_atoms, 3, old_atoms_with_times, '/var/clusterrunner/repos')
         subjobs = atom_grouper.groupings()
 
-        self._assert_groupings_equal(expected_groupings, subjobs)
+        self._assert_subjobs_match_expected_groupings(subjobs, expected_groupings)
 
     def _assert_coalesced_contents(self, coalesced_atoms_with_historic_times, expected_atom_time_values):
         """
         Assert that coalesced_atoms_with_historic_times matches expected_atom_time_values
 
-        :type coalesced_atoms_with_historic_times: list[list[str, float]]
+        :type coalesced_atoms_with_historic_times: list[Atom]
         :type expected_atom_time_values: dict[str, float]
         """
         self.assertEquals(len(coalesced_atoms_with_historic_times), len(expected_atom_time_values))
 
-        for atom_time_pair in coalesced_atoms_with_historic_times:
-            atom = atom_time_pair[0]
-            time = atom_time_pair[1]
-            self.assertTrue(atom_time_pair[0] in expected_atom_time_values, 'No entry for Atom: ' + atom + ' found')
+        for atom in coalesced_atoms_with_historic_times:
+            self.assertTrue(atom.command_string in expected_atom_time_values,
+                            'No entry for Atom: ' + atom.command_string + ' found')
 
-            if atom in expected_atom_time_values:
-                self.assertEquals(time, expected_atom_time_values[atom], 'Incorrect time for atom ' + atom)
+            if atom.command_string in expected_atom_time_values:
+                self.assertEquals(atom.expected_time, expected_atom_time_values[atom.command_string],
+                                  'Incorrect time for atom ' + atom.command_string)
 
-    def _assert_groupings_equal(self, expected, actual):
+    def _assert_subjobs_match_expected_groupings(self, actual_grouped_atoms, expected_groups):
         """
         Assert that the two return subjob groupings are equivalent. The top-level ordering of the lists matters,
         but the inner list ordering does not matter.
 
-        :param expected:
-        :type expected: list[list[str]]
-        :param actual:
-        :type actual: list[list[str]]
+        :type actual_grouped_atoms: list[list[Atom]]
+        :type expected_groups: list[list[str]]
         """
-        self.assertEquals(len(expected), len(actual), 'Incorrect number of subjobs created!')
+        actual_groups = [[atom.command_string for atom in atoms] for atoms in actual_grouped_atoms]
+        self.assertEquals(len(expected_groups), len(actual_groups), 'Incorrect number of subjobs created!')
 
-        for i in range(len(actual)):
-            self.assertEquals(sorted(expected[i]), sorted(actual[i]))
+        for expected_group, actual_group in zip(expected_groups, actual_groups):
+            self.assertCountEqual(expected_group, actual_group)


### PR DESCRIPTION
- Create a new Atom class that takes the place of our existing atoms
which were just strings
- Include both expected and actual time as fields in the Atom object,
and include these in the subjob API response.