### PR TITLE
Only register signal handler for SIGINFO if the platform supports it

### DIFF
--- a/app/util/unhandled_exception_handler.py
+++ b/app/util/unhandled_exception_handler.py
@@ -44,7 +44,11 @@ class UnhandledExceptionHandler(Singleton):
         # singleton is only ever initialized on the main thread.
         signal.signal(signal.SIGTERM, self._application_teardown_signal_handler)
         signal.signal(signal.SIGINT, self._application_teardown_signal_handler)
-        signal.signal(self.SIGINFO, self._application_info_dump_signal_handler)
+        try:
+            signal.signal(self.SIGINFO, self._application_info_dump_signal_handler)
+        except ValueError:
+            self._logger.warning('Failed at registering signal handler for SIGINFO. This is expected if ClusterRunner'
+                                 'is running on Windows.')
 
     @classmethod
     def reset_signal_handlers(cls):

--- a/test/unit/util/test_unhandled_exception_handler.py
+++ b/test/unit/util/test_unhandled_exception_handler.py
@@ -28,6 +28,16 @@ class TestUnhandledExceptionHandler(BaseUnitTestCase):
         exception_was_logged = self.log_handler.has_error('Unhandled exception handler caught exception.')
         self.assertTrue(exception_was_logged, 'Exception handler should log exceptions.')
 
+    def test_handles_platform_does_not_support_SIGINFO(self):
+        UnhandledExceptionHandler.reset_singleton()
+        mock_signal = self.patch('app.util.unhandled_exception_handler.signal')
+
+        def register_signal_handler(sig, _):
+            if sig == UnhandledExceptionHandler.SIGINFO:
+                raise ValueError
+        mock_signal.signal.side_effect = register_signal_handler
+        UnhandledExceptionHandler.singleton()
+
     def test_exceptions_in_teardown_callbacks_are_caught_and_logged(self):
         an_evil_callback = MagicMock(side_effect=Exception)
         self.exception_handler.add_teardown_callback(an_evil_callback)


### PR DESCRIPTION
According to Python documentation, https://docs.python.org/3.4/library/signal.html#signal.signal, on Windows, register signal handler for SIGINFO will raise ValueError. Instead of crashing, we should just swallow the exception and log a warning.

This fixes #152