### PR TITLE
Suppress `AttributeError` while blacklisting methods in base_unit_tes…

### DIFF
--- a/test/framework/base_unit_test_case.py
+++ b/test/framework/base_unit_test_case.py
@@ -224,7 +224,9 @@ class BaseUnitTestCase(TestCase):
         for disabled_reason, patch_targets in blacklisted_methods.items():
             for patch_target in patch_targets:
                 # Suppress UnitTestPatchError, which happens if target has already been patched (no safeguard needed).
-                with suppress(UnitTestPatchError):
+                # Suppress AttributeError, which happens if trying to patch a target that is not available. (e.g.
+                # os.chown on Windows)
+                with suppress(UnitTestPatchError, AttributeError):
                     self._blackist_target(patch_target, disabled_reason)
 
     def _blackist_target(self, patch_target, disabled_reason):


### PR DESCRIPTION
…t_case

Some of the methods being blacklisted are not available on all the platforms. E.g. `os.chown` is not available on Windows. Patching it will raise `AttributeError` and cause all unit tests to fail on Windows.

This fixes #155