### PR TITLE
Fix hard coded path in test_directory

### DIFF
--- a/app/project_type/directory.py
+++ b/app/project_type/directory.py
@@ -30,7 +30,6 @@ class Directory(ProjectType):
         :type remote_files: dict[str, str] | None
         """
         super().__init__(config, job_name, remote_files)
-        project_directory = project_directory
         self._logger = get_logger(__name__)
         self.project_directory = os.path.abspath(project_directory)
         self._logger.debug('Project directory is {}'.format(project_directory))
@@ -52,12 +51,24 @@ class Directory(ProjectType):
 
     def timing_file_path(self, job_name):
         """
+        Construct the sys path of the directory where the timing file should reside based on the project_directory.
+        project_directory is the sys path of the project which contains the clusterrunner.yaml file.
+
+        e.g.:
+        Configuration['timings_directory'] = '/var/timings_directory'
+        project_directory = '/Users/me/project'
+
+        The final timing file sys path should be:
+        '/var/timings_directory/Users/me/project'
+
         :type job_name: str
         :return: the absolute path to where the timing file for job_name SHOULD be. This method does not guarantee
             that the timing file exists.
         :rtype: string
         """
-        timings_subdirectory = os.path.splitdrive(self.project_directory)[1][1:]  # cut off mount point and leading '/'
+        # cut off mount point and leading separator (e.g. '/' on POSIX or '\\' on Windows)
+        # e.g. '/var/bar' would become 'var/bar' on POSIX and 'c:\\temp\\foo' would become 'temp\\foo'
+        timings_subdirectory = os.path.splitdrive(self.project_directory)[1][len(os.sep):]
         return os.path.join(
             Configuration['timings_directory'],
             timings_subdirectory,


### PR DESCRIPTION
In test_directory, tests have hard coded paths (e.g. /var/besttimingserver), which are not cross-platform. This commit changes all the hard coded paths into cross-platform paths by using methods in os.path module and os.getcwd().