### PR TITLE
Deny duplicate cluster slave registration requests on master #171

### DIFF
--- a/app/web_framework/cluster_master_application.py
+++ b/app/web_framework/cluster_master_application.py
@@ -219,7 +219,7 @@ class _SlavesHandler(_ClusterMasterBaseAPIHandler):
     def post(self):
         slave_url = self.decoded_body.get('slave')
         num_executors = int(self.decoded_body.get('num_executors'))
-        response = self._cluster_master.connect_new_slave(slave_url, num_executors)
+        response = self._cluster_master.connect_slave(slave_url, num_executors)
         self._write_status(response, status_code=201)
 
     def get(self):


### PR DESCRIPTION
Addresses https://github.com/box/ClusterRunner/issues/171.

If a ClusterRunner slave that has already been registered with the master attempts to reconnect, we need to make sure the master's internal bookkeeping should be consistent.