### PR TITLE
Fix flaky shutdown test

### DIFF
--- a/app/util/log.py
+++ b/app/util/log.py
@@ -15,6 +15,7 @@ from app.util.conf.configuration import Configuration
 # This custom format string takes care of setting field widths to make logs more aligned and readable.
 _LOG_FORMAT_STRING = (
     '[{record.time!s:.23}] '             # 23 chars of date and time (omits last 3 digits of microseconds)
+    '{record.process:6} '
     '{record.level_name:7} '             # log level - min field width = 7
     '{record.thread_name:15.15} '        # thread name - min and max field width = 15
     '{record.channel:15.15} '            # module name - min and max field width = 15

--- a/app/util/process_utils.py
+++ b/app/util/process_utils.py
@@ -1,3 +1,4 @@
+from contextlib import suppress
 from subprocess import TimeoutExpired
 
 
@@ -14,7 +15,8 @@ def kill_gracefully(process, timeout=2):
     :rtype: (int, str, str)
     """
     try:
-        process.terminate()
+        with suppress(ProcessLookupError):
+            process.terminate()
         stdout, stderr = process.communicate(timeout=timeout)
     except TimeoutExpired:
         process.kill()

--- a/test/framework/functional/functional_test_cluster.py
+++ b/test/framework/functional/functional_test_cluster.py
@@ -273,6 +273,18 @@ class FunctionalTestCluster(object):
         services = [service for service in services if service is not None]  # remove `None` values from list
         return services
 
+    def block_until_n_slaves_dead(self, num_slaves, timeout):
+
+        def are_n_slaves_dead(n):
+            dead_slaves = [slave for slave in self.slaves if not slave.is_alive()]
+            return len(dead_slaves) == n
+
+        def are_slaves_dead():
+            are_n_slaves_dead(num_slaves)
+
+        slaves_died_within_timeout = poll.wait_for(are_slaves_dead, timeout_seconds=timeout)
+        return slaves_died_within_timeout
+
 
 class ClusterService(object):
     """
@@ -309,6 +321,9 @@ class ClusterService(object):
     @property
     def url(self):
         return 'http://{}:{}'.format(self.host, self.port)
+
+    def is_alive(self):
+        return self.process.poll() is None
 
 
 class TestClusterTimeoutError(Exception):

--- a/test/functional/job_configs.py
+++ b/test/functional/job_configs.py
@@ -97,7 +97,7 @@ JobWithSetupAndTeardown:
     teardown_build:
         - echo "Doing build teardown."
         - sleep 1
-        - ALL_SUBJOB_FILES=$(ls $PROJECT_DIR/subjob_file_*.txt || mktemp -t clusterrunner)
+        - ALL_SUBJOB_FILES=$(ls $PROJECT_DIR/subjob_file_*.txt || mktemp -t clusterrunnerXXXX)
         - echo "teardown." | tee -a $ALL_SUBJOB_FILES
 
 """,

--- a/test/functional/master/test_shutdown.py
+++ b/test/functional/master/test_shutdown.py
@@ -19,6 +19,8 @@ class TestShutdown(BaseFunctionalTestCase):
         self.assertEqual(0, len(living_slaves))
         self.assertEqual(2, len(dead_slaves))
 
+        self.cluster.block_until_n_slaves_dead(2, 10)
+
     def test_shutdown_one_slave_should_leave_one_slave_alive(self):
         master = self.cluster.start_master()
         self.cluster.start_slaves(2)
@@ -32,6 +34,8 @@ class TestShutdown(BaseFunctionalTestCase):
 
         self.assertEqual(1, len(living_slaves))
         self.assertEqual(1, len(dead_slaves))
+
+        self.cluster.block_until_n_slaves_dead(1, 10)
 
     def test_shutdown_all_slaves_while_build_is_running_should_finish_build_then_kill_slaves(self):
         master = self.cluster.start_master()


### PR DESCRIPTION
test_shutdown_all_slaves_while_build_is_running_should_finish_build_then_kill_slaves
has been failing sporadically in Travis, but I can't reproduce locally.

mktemp -t fails in Travis if the template does not contain XXXs