### PR TITLE
Fix slave setup race condition

### DIFF
--- a/app/master/slave.py
+++ b/app/master/slave.py
@@ -70,8 +70,9 @@ class Slave(object):
             'project_type_params': slave_project_type_params,
             'build_executor_start_index': build.num_executors_allocated,
         }
-        self._network.post_with_digest(setup_url, post_data, Secret.get())
+
         self.current_build_id = build.build_id()
+        self._network.post_with_digest(setup_url, post_data, Secret.get())
 
     def teardown(self):
         """


### PR DESCRIPTION
This change fixes a relatively rare but real race condition around
slave setup. Previously the master would tell the slave to do setup
and then set slave.current_build_id. There is a small chance,
especially if setup on the slave is fast, that the slave reports back
before the master has set slave.current_build_id. That would cause
an exception.

This should fix #180.