### PR TITLE
Fix coveralls Windows incompatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,5 @@ script:
   - make $TARGETS
 
 after_success:
+  - pip install python-coveralls==2.5.0  # Do not put in requirements.txt; it will not install on Windows.
   - coveralls

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ nosexcover==1.0.10
 pep8==1.5.7
 psutil==2.1.2
 pylint==1.4.2
-python-coveralls==2.5.0
 PyYAML==3.11
 requests==2.3.0
 termcolor==1.1.0


### PR DESCRIPTION
Coveralls is only needed on Travis, so we shouldn't need it in the
general requirements.txt file. In fact if this is present in
requirements.txt then pip install on Windows will fail.