### PR TITLE
Only replace invalid path characters from netloc

### DIFF
--- a/app/util/fs.py
+++ b/app/util/fs.py
@@ -114,14 +114,3 @@ def compress_directories(target_dirs_to_archive_paths, tarfile_path):
             target_dir = os.path.normpath(dir_path)
 
             tar.add(target_dir, arcname=archive_name)
-
-
-def remove_invalid_path_characters(path):
-    """
-    :param path: the path that may contain invalid characters
-    :type path: str
-    :return: the path with the invalid characters removed
-    :rtype: str
-    """
-    # Replace colons and dashes
-    return path.replace(':', '').replace('-', '')


### PR DESCRIPTION
':' is not a valid character in path on Windows. But we cannot replace all colons on a Windows path (e.g. c:\\users\\me).