### PR TITLE
Add Popen_with_deplayed_expansion to process_utils

### DIFF
--- a/test/unit/util/test_process_utils.py
+++ b/test/unit/util/test_process_utils.py
@@ -1,0 +1,43 @@
+from genty import genty, genty_dataset
+
+from app.util.process_utils import Popen_with_delayed_expansion
+
+from test.framework.base_unit_test_case import BaseUnitTestCase
+
+
+@genty
+class TestProcessUtils(BaseUnitTestCase):
+
+    @genty_dataset(
+        str_cmd_on_windows=(
+            'set FOO=1 && echo !FOO!',
+            'nt',
+            ['cmd', '/V', '/C', 'set FOO=1 && echo !FOO!'],
+        ),
+        list_cmd_on_windows=(
+            ['set', 'FOO=1', '&&', 'echo', '!FOO!'],
+            'nt',
+            ['cmd', '/V', '/C', 'set', 'FOO=1', '&&', 'echo', '!FOO!'],
+        ),
+        str_cmd_on_posix=(
+            'export FOO=1; echo $FOO',
+            'posix',
+            'export FOO=1; echo $FOO',
+        ),
+        list_cmd_on_posix=(
+            ['export', 'FOO=1;', 'echo', '$FOO'],
+            'posix',
+            ['export', 'FOO=1;', 'echo', '$FOO'],
+        ),
+    )
+    def test_Popen_with_deplayed_expansion(self, input_cmd, os_name, expected_final_cmd):
+        # Arrange
+        mock_os = self.patch('app.util.process_utils.os')
+        mock_os.name = os_name
+        mock_subprocess_popen = self.patch('subprocess.Popen')
+
+        # Act
+        Popen_with_delayed_expansion(input_cmd)
+
+        # Assert
+        mock_subprocess_popen.assert_called_once_with(expected_final_cmd)


### PR DESCRIPTION
On Windows, by default, environment variables are expanded before execution. This behavior is not what we want. Popen_with_deplayed_expansion is a thin wrapper around subprocess.Popen which tweaks the incoming cmd a little bit, which makes sure the environment variables will be expanded during execution, before passing it to the subprocess.Popen.