### PR TITLE
Make job_configs for multiple platforms

### DIFF
--- a/test/functional/job_configs.py
+++ b/test/functional/job_configs.py
@@ -23,8 +23,8 @@ class FunctionalTestJobConfig(object):
 
 # This is a very basic job where each atom just creates a simple text file.
 BASIC_JOB = FunctionalTestJobConfig(
-    config="""
-
+    config={
+        'posix': """
 BasicJob:
     commands:
         - echo $TOKEN > $ARTIFACT_DIR/result.txt
@@ -32,6 +32,14 @@ BasicJob:
         - TOKEN: seq 0 4 | xargs -I {} echo "This is atom {}"
 
 """,
+        'nt': """
+BasicJob:
+    commands:
+        - echo !TOKEN!> !ARTIFACT_DIR!\\result.txt
+    atomizers:
+        - TOKEN: FOR /l %n in (0,1,4) DO @echo This is atom %n
+""",
+    },
     expected_to_fail=False,
     expected_num_subjobs=5,
     expected_num_atoms=5,
@@ -48,8 +56,8 @@ BasicJob:
 
 # This is a very basic job, but one of the atoms will fail with non-zero exit code.
 BASIC_FAILING_JOB = FunctionalTestJobConfig(
-    config="""
-
+    config={
+        'posix': """
 BasicFailingJob:
     commands:
         - if [ "$TOKEN" = "This is atom 3" ]; then exit 1; fi
@@ -58,6 +66,14 @@ BasicFailingJob:
         - TOKEN: seq 0 4 | xargs -I {} echo "This is atom {}"
 
 """,
+        'nt': """
+BasicFailingJob:
+    commands:
+        - IF "!TOKEN!" == "This is atom 3" (EXIT 1) ELSE (echo !TOKEN!> !ARTIFACT_DIR!\\result.txt)
+    atomizers:
+        - TOKEN: FOR /l %n in (0,1,4) DO @echo This is atom %n
+""",
+    },
     expected_to_fail=True,
     expected_num_subjobs=5,
     expected_num_atoms=5,
@@ -76,7 +92,8 @@ BasicFailingJob:
 # This is a more complex job. Each step (setup_build, commands, teardown_build) depends on the previous steps. This
 # config also includes short sleeps to help tease out race conditions around setup and teardown timing.
 JOB_WITH_SETUP_AND_TEARDOWN = FunctionalTestJobConfig(
-    config="""
+    config={
+        'posix': """
 
 JobWithSetupAndTeardown:
     setup_build:
@@ -101,6 +118,9 @@ JobWithSetupAndTeardown:
         - echo "teardown." | tee -a $ALL_SUBJOB_FILES
 
 """,
+        'nt': """
+""",
+    },
     expected_to_fail=False,
     expected_num_subjobs=3,
     expected_num_atoms=3,

--- a/test/functional/master/test_endpoints.py
+++ b/test/functional/master/test_endpoints.py
@@ -1,3 +1,5 @@
+import os
+
 from test.framework.functional.base_functional_test_case import BaseFunctionalTestCase
 from test.functional.job_configs import BASIC_JOB
 
@@ -9,7 +11,7 @@ class TestMasterEndpoints(BaseFunctionalTestCase):
 
         build_resp = master.post_new_build({
             'type': 'directory',
-            'config': BASIC_JOB.config,
+            'config': BASIC_JOB.config[os.name],
             'project_directory': '/tmp',
             })
         build_id = build_resp['build_id']

--- a/test/functional/master/test_shutdown.py
+++ b/test/functional/master/test_shutdown.py
@@ -1,4 +1,6 @@
+import os
 import tempfile
+
 from test.framework.functional.base_functional_test_case import BaseFunctionalTestCase
 from test.functional.job_configs import JOB_WITH_SETUP_AND_TEARDOWN
 
@@ -44,7 +46,7 @@ class TestShutdown(BaseFunctionalTestCase):
         project_dir = tempfile.TemporaryDirectory()
         build_resp = master.post_new_build({
             'type': 'directory',
-            'config': JOB_WITH_SETUP_AND_TEARDOWN.config,
+            'config': JOB_WITH_SETUP_AND_TEARDOWN.config[os.name],
             'project_directory': project_dir.name,
             })
         build_id = build_resp['build_id']

--- a/test/functional/test_cluster_basic.py
+++ b/test/functional/test_cluster_basic.py
@@ -1,6 +1,8 @@
-from genty import genty, genty_dataset
+import os
 import tempfile
 from unittest import skip
+
+from genty import genty, genty_dataset
 
 from test.framework.functional.base_functional_test_case import BaseFunctionalTestCase
 from test.framework.functional.fs_item import Directory, File
@@ -22,7 +24,7 @@ class TestClusterBasic(BaseFunctionalTestCase):
         project_dir = tempfile.TemporaryDirectory()
         build_resp = master.post_new_build({
             'type': 'directory',
-            'config': test_job_config.config,
+            'config': test_job_config.config[os.name],
             'project_directory': project_dir.name,
         })
         build_id = build_resp['build_id']


### PR DESCRIPTION
Before this commit, job_configs has three configs that only works in POSIX systems. This commit makes it so that each config contains a dictionary pointing to different real configs for different underlying platform so running the functional test on Windows will run Windows command and on Mac will run POSIX commands.