### PR TITLE
Fix yaml filename inconsistencies in docstrings

### DIFF
--- a/app/master/build_request.py
+++ b/app/master/build_request.py
@@ -3,7 +3,7 @@ This class is a data object for the build request parameters provided by the use
 validation.
 
 A requirement with the request that it must be able to specify where the cluster runner configuration file
-is going to live (cluster_runner.yaml). The cluster runner will look in the top level project directory
+is going to live (clusterrunner.yaml). The cluster runner will look in the top level project directory
 for this file. If it doesn't exist, it is a fatal error and the build will be immediately aborted.
 
 The only field that is consistently required for ALL types is the "type" field.

--- a/app/master/build_request_handler.py
+++ b/app/master/build_request_handler.py
@@ -133,7 +133,7 @@ class BuildRequestHandler(object):
         job_config = project_type.job_config()
 
         if job_config is None:
-            build.mark_failed('Build failed while trying to parse cluster_runner.yaml.')
+            build.mark_failed('Build failed while trying to parse clusterrunner.yaml.')
             return
 
         subjobs = self._compute_subjobs_for_build(build_id, job_config, project_type)

--- a/app/master/subjob.py
+++ b/app/master/subjob.py
@@ -19,7 +19,7 @@ class Subjob(object):
         :type subjob_id: int
         :param project_type:
         :type project_type: ProjectType
-        :param job_config: the job's configuration from cluster_runner.yaml
+        :param job_config: the job's configuration from clusterrunner.yaml
         :type job_config: JobConfig
         :param atoms: the atom project_type strings
         :type atoms: list[app.master.atom.Atom]

--- a/app/project_type/directory.py
+++ b/app/project_type/directory.py
@@ -20,9 +20,9 @@ class Directory(ProjectType):
         Note: the first line of each parameter docstring will be exposed as command line argument documentation for the
         clusterrunner build client.
 
-        :param project_directory: path to the directory that contains the project and cluster_runner.yaml
+        :param project_directory: path to the directory that contains the project and clusterrunner.yaml
         :type project_directory: string
-        :param config: a yaml string to be used in place of a cluster_runner.yaml
+        :param config: a yaml string to be used in place of a clusterrunner.yaml
         :type config: string|None
         :param job_name: a list of job names we intend to run
         :type job_name: list [str] | None

--- a/app/project_type/git.py
+++ b/app/project_type/git.py
@@ -61,7 +61,7 @@ class Git(ProjectType):
         :type url: str
         :param build_project_directory: the symlinked directory of where PROJECT_DIR should end up being set to
         :type build_project_directory: str
-        :param project_directory: path within the repo that contains cluster_runner.yaml
+        :param project_directory: path within the repo that contains clusterrunner.yaml
         :type project_directory: str
         :param remote: The git remote name to fetch from
         :type remote: str

--- a/app/project_type/project_type.py
+++ b/app/project_type/project_type.py
@@ -17,7 +17,7 @@ class ProjectType(object):
 
     def __init__(self, config=None, job_name=None, remote_files=None):
         """
-        :param config: A yaml string representing a cluster_runner.yaml file
+        :param config: A yaml string representing a clusterrunner.yaml file
         :type config: str | None
         :type job_name: str | None
         :param remote_files: key-value pairs of where the key is the output_file and the value is the url
@@ -55,9 +55,9 @@ class ProjectType(object):
 
     def _get_config_contents(self):
         """
-        Default method for retriving the contents of cluster_runner.yaml.  Override this in project types using a
+        Default method for retriving the contents of clusterrunner.yaml.  Override this in project types using a
         different method
-        :return: The contents of cluster_runner.yaml
+        :return: The contents of clusterrunner.yaml
         :rtype: str
         """
         if self._config is not None:


### PR DESCRIPTION
Several places in the code had docstrings referring to
"cluster_runner.yaml" which is misleading since the file we look for
by default is actually "clusterrunner.yaml".