### PR TITLE
Replace Popen in app with Popen_with_delayed_expansion

### DIFF
--- a/app/client/service_runner.py
+++ b/app/client/service_runner.py
@@ -1,10 +1,11 @@
 import requests
-from subprocess import Popen, DEVNULL
+from subprocess import DEVNULL
 import time
 
 from app.util.conf.configuration import Configuration
 from app.util.log import get_logger
 from app.util.network import Network
+from app.util.process_utils import Popen_with_delayed_expansion
 from app.util.url_builder import UrlBuilder
 from app.util import poll
 
@@ -98,7 +99,7 @@ class ServiceRunner(object):
         """
         if service_url is not None and self.is_up(service_url):
             return
-        Popen(cmd, stdout=DEVNULL, shell=True)
+        Popen_with_delayed_expansion(cmd, stdout=DEVNULL, shell=True)
         if service_url is not None and not self.is_up(service_url, timeout=10):
             raise ServiceRunError("Failed to run service on {}.".format(service_url))
 

--- a/app/project_type/project_type.py
+++ b/app/project_type/project_type.py
@@ -3,7 +3,7 @@ import inspect
 import os
 import re
 import signal
-from subprocess import Popen, TimeoutExpired
+from subprocess import TimeoutExpired
 from tempfile import TemporaryFile
 from threading import Event
 import time
@@ -11,6 +11,7 @@ import time
 from app.master.cluster_runner_config import ClusterRunnerConfig
 from app.util import log
 from app.util.conf.configuration import Configuration
+from app.util.process_utils import Popen_with_delayed_expansion
 
 
 class ProjectType(object):
@@ -191,7 +192,7 @@ class ProjectType(object):
         # Redirect output to files instead of using pipes to avoid: https://github.com/box/ClusterRunner/issues/57
         stdout_file = TemporaryFile()
         stderr_file = TemporaryFile()
-        pipe = Popen(
+        pipe = Popen_with_delayed_expansion(
             command,
             shell=True,
             stdout=stdout_file,

--- a/app/util/fs.py
+++ b/app/util/fs.py
@@ -2,7 +2,8 @@ import os
 import shutil
 import tarfile
 import tempfile
-import subprocess
+
+from app.util.process_utils import Popen_with_delayed_expansion
 
 
 def async_delete(path):
@@ -20,7 +21,7 @@ def async_delete(path):
     """
     new_temp_path = tempfile.mkdtemp(prefix='async_delete_directory')
     shutil.move(path, new_temp_path)
-    subprocess.Popen(['rm', '-rf', new_temp_path])
+    Popen_with_delayed_expansion(['rm', '-rf', new_temp_path])
 
 
 def create_dir(dir_path, mode=None):

--- a/app/util/shell/local_shell_client.py
+++ b/app/util/shell/local_shell_client.py
@@ -1,7 +1,8 @@
 import shutil
-from subprocess import Popen, PIPE, DEVNULL
+from subprocess import PIPE, DEVNULL
 
 from app.util.log import get_logger
+from app.util.process_utils import Popen_with_delayed_expansion
 from app.util.shell.shell_client import ShellClient, Response, EmptyResponse
 
 
@@ -18,7 +19,7 @@ class LocalShellClient(ShellClient):
         """
         # todo investigate why this assignment is required for launching async operations using Popen
         self._logger.debug('popen async [{}:{}]: {}'.format(self.user, self.host, command))
-        proc = Popen(command, shell=True, stdout=DEVNULL, stderr=DEVNULL)
+        Popen_with_delayed_expansion(command, shell=True, stdout=DEVNULL, stderr=DEVNULL)
         return EmptyResponse()
 
     def _exec_command_on_client_blocking(self, command):
@@ -28,7 +29,7 @@ class LocalShellClient(ShellClient):
         :return:
         :rtype: Response
         """
-        proc = Popen(command, shell=True, stdout=PIPE, stderr=PIPE)
+        proc = Popen_with_delayed_expansion(command, shell=True, stdout=PIPE, stderr=PIPE)
         self._logger.debug('popen blocking [{}:{}]: {}'.format(self.user, self.host, command))
         output, error = proc.communicate()
         return Response(raw_output=output, raw_error=error, returncode=proc.returncode)

--- a/app/util/shell/remote_shell_client.py
+++ b/app/util/shell/remote_shell_client.py
@@ -1,6 +1,7 @@
-from subprocess import Popen, PIPE, DEVNULL
+from subprocess import PIPE, DEVNULL
 
 from app.util.log import get_logger
+from app.util.process_utils import Popen_with_delayed_expansion
 from app.util.shell.shell_client import ShellClient, Response, EmptyResponse
 
 
@@ -16,7 +17,7 @@ class RemoteShellClient(ShellClient):
         """
         escaped_command = self._escaped_ssh_command(command)
         self._logger.debug('SSH popen async [{}:{}]: {}'.format(self.user, self.host, escaped_command))
-        proc = Popen(escaped_command, shell=True, stdout=DEVNULL, stderr=DEVNULL)
+        Popen_with_delayed_expansion(escaped_command, shell=True, stdout=DEVNULL, stderr=DEVNULL)
         return EmptyResponse()
 
     def _exec_command_on_client_blocking(self, command):
@@ -26,7 +27,7 @@ class RemoteShellClient(ShellClient):
         """
         escaped_command = self._escaped_ssh_command(command)
         self._logger.debug('SSH popen blocking [{}:{}]: {}'.format(self.user, self.host, escaped_command))
-        proc = Popen(escaped_command, shell=True, stdout=PIPE, stderr=PIPE)
+        proc = Popen_with_delayed_expansion(escaped_command, shell=True, stdout=PIPE, stderr=PIPE)
         output, error = proc.communicate()
         return Response(raw_output=output, raw_error=error, returncode=proc.returncode)
 
@@ -39,7 +40,7 @@ class RemoteShellClient(ShellClient):
         # Avoid any ssh known_hosts prompts.
         command = 'scp -o StrictHostKeyChecking=no {} {}:{}'.format(source, self._host_string(), destination)
         self._logger.debug('SCP popen blocking [{}:{}]: {}'.format(self.user, self.host, command))
-        proc = Popen(command, shell=True, stdout=PIPE, stderr=PIPE)
+        proc = Popen_with_delayed_expansion(command, shell=True, stdout=PIPE, stderr=PIPE)
         output, error = proc.communicate()
         return Response(raw_output=output, raw_error=error, returncode=proc.returncode)
 

--- a/test/unit/client/test_service_runner.py
+++ b/test/unit/client/test_service_runner.py
@@ -8,7 +8,7 @@ class TestServiceRunner(BaseUnitTestCase):
 
     def setUp(self):
         super().setUp()
-        self.mock_Popen = self.patch('app.client.service_runner.Popen')
+        self.mock_Popen = self.patch('app.client.service_runner.Popen_with_delayed_expansion')
         self.mock_Network = self.patch('app.client.service_runner.Network')
         self.mock_time = self.patch('app.client.service_runner.time')
 

--- a/test/unit/project_type/test_git.py
+++ b/test/unit/project_type/test_git.py
@@ -186,7 +186,7 @@ class TestGit(BaseUnitTestCase):
         """
         command_to_result_map = command_to_result_map or {}
         self.patch('app.project_type.project_type.TemporaryFile', new=lambda: Mock())
-        project_type_popen_patch = self.patch('app.project_type.project_type.Popen')
+        project_type_popen_patch = self.patch('app.project_type.project_type.Popen_with_delayed_expansion')
 
         def fake_popen_constructor(command, stdout, stderr, *args, **kwargs):
             fake_result = _FakePopenResult()  # default value

--- a/test/unit/project_type/test_project_type.py
+++ b/test/unit/project_type/test_project_type.py
@@ -14,7 +14,7 @@ class TestProjectType(BaseUnitTestCase):
 
     def setUp(self):
         super().setUp()
-        self.mock_popen = self.patch('app.project_type.project_type.Popen').return_value
+        self.mock_popen = self.patch('app.project_type.project_type.Popen_with_delayed_expansion').return_value
         try:
             self.mock_kill = self.patch('os.killpg')
         except AttributeError:

--- a/test/unit/util/shell/test_local_shell_client.py
+++ b/test/unit/util/shell/test_local_shell_client.py
@@ -16,7 +16,7 @@ class TestLocalShellClient(BaseUnitTestCase):
     def setUp(self):
         super().setUp()
         self.mock_shutil = self.patch('app.util.shell.local_shell_client.shutil')
-        self.mock_Popen = self.patch('app.util.shell.local_shell_client.Popen')
+        self.mock_Popen = self.patch('app.util.shell.local_shell_client.Popen_with_delayed_expansion')
 
     @genty_dataset(
         empty_response=(True, EmptyResponse()),

--- a/test/unit/util/shell/test_remote_shell_client.py
+++ b/test/unit/util/shell/test_remote_shell_client.py
@@ -9,7 +9,7 @@ from test.framework.base_unit_test_case import BaseUnitTestCase
 class TestRemoteShellClient(BaseUnitTestCase):
     def setUp(self):
         super().setUp()
-        self.mock_Popen = self.patch('app.util.shell.remote_shell_client.Popen')
+        self.mock_Popen = self.patch('app.util.shell.remote_shell_client.Popen_with_delayed_expansion')
 
     @genty_dataset(
         normal_response=(False, Response(raw_output=b'\ncat', raw_error=b'\ndog', returncode=0)),


### PR DESCRIPTION
Popen_with_delayed_expansion is a cross-platform wrapper around Popen which make sure all the environment variables in the command will be expanded only at execution time. Due to how ClusterRunner chains all commands together, this is almost always the behavior we want.