### PR TITLE
Skip clusterrunner.conf file mode on Windows

### DIFF
--- a/app/util/conf/config_file.py
+++ b/app/util/conf/config_file.py
@@ -3,6 +3,7 @@ import os
 import stat
 
 from app.util import fs
+from app.util.process_utils import is_windows
 
 
 class ConfigFile(object):
@@ -21,7 +22,7 @@ class ConfigFile(object):
         if not os.path.isfile(self._filename):
             raise FileNotFoundError('Conf file {} does not exist'.format(self._filename))
         file_mode = stat.S_IMODE(os.stat(self._filename).st_mode)
-        if file_mode != self.CONFIG_FILE_MODE:
+        if is_windows() or file_mode != self.CONFIG_FILE_MODE:
             raise PermissionError('The conf file {} has incorrect permissions, '
                                   'should be 0600 for security reasons'.format(self._filename))
         config_parsed = ConfigObj(self._filename)

--- a/app/util/process_utils.py
+++ b/app/util/process_utils.py
@@ -27,7 +27,7 @@ def kill_gracefully(process, timeout=2):
     return process.returncode, stdout, stderr
 
 
-def _is_windows():
+def is_windows():
     """
     :return: Whether ClusterRunner is running on Windows or not>
     :rtype: bool
@@ -48,7 +48,7 @@ def Popen_with_delayed_expansion(cmd, *args, **kwargs):
     :return: Popen object, just like the Popen object returned by subprocess.Popen
     :rtype: :class:`Popen`
     """
-    if _is_windows():
+    if is_windows():
         cmd_with_deplayed_expansion = ['cmd', '/V', '/C']
         if isinstance(cmd, str):
             cmd_with_deplayed_expansion.append(cmd)
@@ -70,7 +70,7 @@ def get_environment_variable_setter_command(name, value):
     :return: Platform specific command for setting the environment variable
     :rtype: str
     """
-    if _is_windows():
+    if is_windows():
         return 'set {}={}&&'.format(name, value)
     else:
         return 'export {}="{}";'.format(name, value)


### PR DESCRIPTION
Permission model on Windows is different than Mac. Python doesn't support Windows file permission very well.
Skip the check on Windows for now. Since the clusterrunner.conf file should live in the user's home directory,
which is usually not accessible by others, this is OK for now.