### PR TITLE
Make test_atomizer cross platform

### DIFF
--- a/test/unit/master/test_atomizer.py
+++ b/test/unit/master/test_atomizer.py
@@ -2,11 +2,12 @@ from unittest.mock import MagicMock
 from app.master.atomizer import Atomizer, AtomizerError
 
 from app.project_type.project_type import ProjectType
+from app.util.process_utils import get_environment_variable_setter_command
 from test.framework.base_unit_test_case import BaseUnitTestCase
 
 
 _FAKE_ATOMIZER_COMMAND = 'find . -name test_*.py'
-_FAKE_ATOMIZER_COMMAND_OUTPUT = './test_a.py\n./test_b.py\n./test_c.py\n'
+_FAKE_ATOMIZER_COMMAND_OUTPUT = 'test_a.py\ntest_b.py\ntest_c.py\n'
 _SUCCESSFUL_EXIT_CODE = 0
 _FAILING_EXIT_CODE = 1
 
@@ -20,9 +21,11 @@ class TestAtomizer(BaseUnitTestCase):
         actual_atoms = atomizer.atomize_in_project(mock_project)
         actual_atom_commands = [atom.command_string for atom in actual_atoms]
 
-        expected_atom_commands = ['export TEST_FILE="./test_a.py";',
-                                  'export TEST_FILE="./test_b.py";',
-                                  'export TEST_FILE="./test_c.py";']
+        expected_atom_commands = [
+            get_environment_variable_setter_command('TEST_FILE', 'test_a.py'),
+            get_environment_variable_setter_command('TEST_FILE', 'test_b.py'),
+            get_environment_variable_setter_command('TEST_FILE', 'test_c.py'),
+        ]
         self.assertListEqual(expected_atom_commands, actual_atom_commands,
                              'List of actual atoms should match list of expected atoms.')
         mock_project.execute_command_in_project.assert_called_once_with(_FAKE_ATOMIZER_COMMAND)


### PR DESCRIPTION
There were hard coded environment variable setter commands in the tests that fail on Windows.
This commit uses the `get_environment_variable_setter_command` instead.