### PR TITLE
Patch Popen_with_delayed_expansion instead of Popen

### DIFF
--- a/app/util/fs.py
+++ b/app/util/fs.py
@@ -21,6 +21,7 @@ def async_delete(path):
     """
     new_temp_path = tempfile.mkdtemp(prefix='async_delete_directory')
     shutil.move(path, new_temp_path)
+    # TODO: make the following command cross-platform.
     Popen_with_delayed_expansion(['rm', '-rf', new_temp_path])
 
 

--- a/test/unit/util/test_fs.py
+++ b/test/unit/util/test_fs.py
@@ -5,7 +5,7 @@ from test.framework.base_unit_test_case import BaseUnitTestCase
 class TestFs(BaseUnitTestCase):
 
     def test_async_delete_calls_correct_commands(self):
-        popen_mock = self.patch('subprocess.Popen')
+        popen_mock = self.patch('app.util.fs.Popen_with_delayed_expansion')
         move_mock = self.patch('shutil.move')
         self.patch('os.path.isdir').return_value = True
         mkdtemp_mock = self.patch('tempfile.mkdtemp')


### PR DESCRIPTION
The test used to patch subprocess.Popen. It fails on Windows as we invoke different commands
on Popen depending on the platform. Patching Popen_with_deplayed_expansion instead so the test is
cross platform.