### PR TITLE
Remove the trailing spaces from the command constructd by chaining a …

### DIFF
--- a/app/master/cluster_runner_config.py
+++ b/app/master/cluster_runner_config.py
@@ -148,7 +148,7 @@ class ClusterRunnerConfig(object):
 
     def _shell_command_list_to_single_command(self, commands):
         """
-        Combines a list of commands into a single bash string
+        Combines a list of commands into a single command string
         :param commands: a list of commands, optionally ending with semicolons
         :type commands: list[str|None]
         :return: returns the concatenated shell command on success, or None if there was an error
@@ -174,7 +174,7 @@ class ClusterRunnerConfig(object):
         joined_commands = ''.join(sanitized_commands).strip()
 
         if joined_commands.endswith('&&'):
-            joined_commands = joined_commands.rstrip('&')
+            joined_commands = joined_commands.rstrip('&').strip()
 
         return joined_commands
 

--- a/test/unit/master/test_cluster_runner_config.py
+++ b/test/unit/master/test_cluster_runner_config.py
@@ -102,12 +102,12 @@ class TestClusterRunnerConfig(BaseUnitTestCase):
         complete_valid_config=(_COMPLETE_VALID_CONFIG, {
             'name': 'Best Job Ever',
             'max_executors': 21,
-            'setup_build': 'echo "This is setup! Woo!" && sleep 1 ',
-            'command': 'echo "Now I\'m doing $THE_THING!" && echo "Semicolons are fun." > /tmp/my_hard_work.txt ',
+            'setup_build': 'echo "This is setup! Woo!" && sleep 1',
+            'command': 'echo "Now I\'m doing $THE_THING!" && echo "Semicolons are fun." > /tmp/my_hard_work.txt',
             'atomizer': [{'THE_THING': 'printf \'something with a number %d\\n\' {1..50}'}],
         }),
         valid_config_with_empty_command=(_VALID_CONFIG_WITH_EMPTY_COMMANDS, {
-            'command': 'echo "first" && echo "last" ',
+            'command': 'echo "first" && echo "last"',
             'atomizer': [{'ENV_VAR': 'echo "atom"'}],
         }),
     )
@@ -168,4 +168,4 @@ class TestClusterRunnerConfig(BaseUnitTestCase):
         config = ClusterRunnerConfig(self._BACKGROUND_TASK_CONFIG)
         job_config = config.get_job_config()
         self.assertEqual(job_config.setup_build,
-                         'echo "in the background" & echo "in the foreground"  && echo "another thing" ')
+                         'echo "in the background" & echo "in the foreground"  && echo "another thing"')


### PR DESCRIPTION
…list of commands

The trailing space is fine in bash not less so in windows command prompt.