### PR TITLE
Instead of writing stdout/ stderr to temp files, write to artifact path

### DIFF
--- a/app/slave/subjob_executor.py
+++ b/app/slave/subjob_executor.py
@@ -131,13 +131,13 @@ class SubjobExecutor(object):
         :rtype: int
         """
         fs_util.create_dir(atom_artifact_dir)
-
-        start_time = time.time()
-        output, exit_code = self._project_type.execute_command_in_project(atomic_command, atom_environment_vars)
-        elapsed_time = time.time() - start_time
-
-        console_output_path = os.path.join(atom_artifact_dir, Subjob.OUTPUT_FILE)
-        fs_util.write_file(output, console_output_path)
+        # This console_output_file must be opened in 'w+b' mode in order to be interchangeable with the
+        # TemporaryFile instance that gets instantiated in self._project_type.execute_command_in_project.
+        with open(os.path.join(atom_artifact_dir, Subjob.OUTPUT_FILE), mode='w+b') as console_output_file:
+            start_time = time.time()
+            _, exit_code = self._project_type.execute_command_in_project(atomic_command, atom_environment_vars,
+                                                                         output_file=console_output_file)
+            elapsed_time = time.time() - start_time
 
         exit_code_output_path = os.path.join(atom_artifact_dir, Subjob.EXIT_CODE_FILE)
         fs_util.write_file(str(exit_code) + '\n', exit_code_output_path)

--- a/test/unit/project_type/test_git.py
+++ b/test/unit/project_type/test_git.py
@@ -252,7 +252,6 @@ class TestGit(BaseUnitTestCase):
                     fake_result = command_to_result_map[command_regex]
                     break
             stdout.read.return_value = fake_result.stdout.encode()
-            stderr.read.return_value = fake_result.stderr.encode()
             return Mock(spec=Popen, returncode=fake_result.return_code)
 
         project_type_popen_patch.side_effect = fake_popen_constructor

--- a/test/unit/slave/test_subjob_executor.py
+++ b/test/unit/slave/test_subjob_executor.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock
+from unittest.mock import Mock, mock_open
 
 from app.slave.subjob_executor import SubjobExecutor
 from test.framework.base_unit_test_case import BaseUnitTestCase
@@ -40,6 +40,7 @@ class TestSubjobExecutor(BaseUnitTestCase):
         executor._project_type.execute_command_in_project = Mock(return_value=(1, 2))
         self.patch('app.slave.subjob_executor.fs_util')
         self.patch('app.slave.subjob_executor.shutil')
+        output_file_mock = self.patch('app.slave.subjob_executor.open', new=mock_open(read_data=''), create=True).return_value
         os = self.patch('app.slave.subjob_executor.os')
         os.path = Mock()
         os.path.join = Mock(return_value='path')
@@ -56,4 +57,5 @@ class TestSubjobExecutor(BaseUnitTestCase):
         executor.execute_subjob(build_id=1, subjob_id=2, subjob_artifact_dir='dir', atomic_commands=atomic_commands,
                                 base_executor_index=6)
 
-        executor._project_type.execute_command_in_project.assert_called_with('command', expected_env_vars)
+        executor._project_type.execute_command_in_project.assert_called_with('command', expected_env_vars,
+                                                                             output_file=output_file_mock)


### PR DESCRIPTION
On the slave service, we are writing stdout and stderr to two separate
temporary files, and later copying the contents of them to its final
path in the artifact directory.

This will not only be slightly more efficient, but it allows us to
implement returning the console output of in-progress builds from
slaves.