### PR TITLE
Centralize functionality for calculating the build artifact path

### DIFF
--- a/app/master/slave.py
+++ b/app/master/slave.py
@@ -103,10 +103,7 @@ class Slave(object):
         :type subjob: Subjob
         """
         execution_url = self._slave_api.url('build', subjob.build_id(), 'subjob', subjob.subjob_id())
-        post_data = {
-            'subjob_artifact_dir': subjob.artifact_dir(),
-            'atomic_commands': subjob.atomic_commands(),
-        }
+        post_data = {'atomic_commands': subjob.atomic_commands()}
         response = self._network.post_with_digest(execution_url, post_data, Secret.get(), error_on_failure=True)
 
         subjob_executor_id = response.json().get('executor_id')

--- a/app/slave/subjob_executor.py
+++ b/app/slave/subjob_executor.py
@@ -2,7 +2,8 @@ import os
 import shutil
 import time
 
-from app.master.subjob import Subjob
+from app.master.build import BuildArtifact
+from app.util.conf.configuration import Configuration
 import app.util.fs as fs_util  # todo(joey): Rename util.py so we don't have package names conflicting with module names
 from app.util import analytics, log, util
 
@@ -49,14 +50,13 @@ class SubjobExecutor(object):
     def run_job_config_setup(self):
         self._project_type.run_job_config_setup()
 
-    def execute_subjob(self, build_id, subjob_id, subjob_artifact_dir, atomic_commands, base_executor_index):
+    def execute_subjob(self, build_id, subjob_id, atomic_commands, base_executor_index):
         """
         This is the method for executing a subjob. This performs the work required by executing the specified command,
         then archives the results into a single file and returns the filename.
 
         :type build_id: int
         :type subjob_id: int
-        :type subjob_artifact_dir: str
         :type atomic_commands: list[str]
         :type base_executor_index: int
         :rtype: str
@@ -72,9 +72,12 @@ class SubjobExecutor(object):
 
         # execute every atom and keep track of time elapsed for each
         for atom_id, atomic_command in enumerate(atomic_commands):
-
-            atom_artifact_dir = os.path.join(subjob_artifact_dir,
-                                             Subjob.ATOM_DIR_FORMAT.format(subjob_id, atom_id))
+            atom_artifact_dir = BuildArtifact.atom_artifact_directory(
+                build_id,
+                subjob_id,
+                atom_id,
+                result_root=Configuration['artifact_directory']
+            )
 
             # remove and recreate the atom artifact dir
             shutil.rmtree(atom_artifact_dir, ignore_errors=True)
@@ -104,6 +107,8 @@ class SubjobExecutor(object):
                                     for atom_dir in atom_artifact_dirs}
 
         # zip file names must be unique for a build, so we append the subjob_id to the compressed file
+        subjob_artifact_dir = BuildArtifact.build_artifact_directory(build_id,
+                                                                     result_root=Configuration['artifact_directory'])
         tarfile_path = os.path.join(subjob_artifact_dir, 'results_{}.tar.gz'.format(subjob_id))
         fs_util.compress_directories(targets_to_archive_paths, tarfile_path)
 
@@ -133,19 +138,19 @@ class SubjobExecutor(object):
         fs_util.create_dir(atom_artifact_dir)
         # This console_output_file must be opened in 'w+b' mode in order to be interchangeable with the
         # TemporaryFile instance that gets instantiated in self._project_type.execute_command_in_project.
-        with open(os.path.join(atom_artifact_dir, Subjob.OUTPUT_FILE), mode='w+b') as console_output_file:
+        with open(os.path.join(atom_artifact_dir, BuildArtifact.OUTPUT_FILE), mode='w+b') as console_output_file:
             start_time = time.time()
             _, exit_code = self._project_type.execute_command_in_project(atomic_command, atom_environment_vars,
                                                                          output_file=console_output_file)
             elapsed_time = time.time() - start_time
 
-        exit_code_output_path = os.path.join(atom_artifact_dir, Subjob.EXIT_CODE_FILE)
+        exit_code_output_path = os.path.join(atom_artifact_dir, BuildArtifact.EXIT_CODE_FILE)
         fs_util.write_file(str(exit_code) + '\n', exit_code_output_path)
 
-        command_output_path = os.path.join(atom_artifact_dir, Subjob.COMMAND_FILE)
+        command_output_path = os.path.join(atom_artifact_dir, BuildArtifact.COMMAND_FILE)
         fs_util.write_file(str(atomic_command) + '\n', command_output_path)
 
-        time_output_path = os.path.join(atom_artifact_dir, Subjob.TIMING_FILE)
+        time_output_path = os.path.join(atom_artifact_dir, BuildArtifact.TIMING_FILE)
         fs_util.write_file('{:.2f}\n'.format(elapsed_time), time_output_path)
 
         return exit_code

--- a/app/web_framework/cluster_slave_application.py
+++ b/app/web_framework/cluster_slave_application.py
@@ -102,11 +102,10 @@ class _SubjobsHandler(_ClusterSlaveBaseAPIHandler):
 class _SubjobHandler(_ClusterSlaveBaseAPIHandler):
     @authenticated
     def post(self, build_id, subjob_id):
-        subjob_artifact_dir = self.decoded_body.get('subjob_artifact_dir')
         atomic_commands = self.decoded_body.get('atomic_commands')
 
         response = self._cluster_slave.start_working_on_subjob(
-            int(build_id), int(subjob_id), subjob_artifact_dir, atomic_commands
+            int(build_id), int(subjob_id), atomic_commands
         )
         self._write_status(response, status_code=201)
 

--- a/test/unit/master/test_build.py
+++ b/test/unit/master/test_build.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, Mock, mock_open
 from app.master.atom import Atom, AtomState
 from app.master.atomizer import Atomizer
 from app.master.build import Build, BuildStatus, BuildProjectError
+from app.master.build_artifact import BuildArtifact
 from app.master.build_request import BuildRequest
 from app.master.job_config import JobConfig
 from app.master.slave import Slave
@@ -171,7 +172,7 @@ class TestBuild(BaseUnitTestCase):
 
         expected_payload_sys_path = join(Configuration['results_directory'], '1', 'artifact_0_0')
         m_open.assert_called_once_with(
-            join(expected_payload_sys_path, Subjob.EXIT_CODE_FILE),
+            join(expected_payload_sys_path, BuildArtifact.EXIT_CODE_FILE),
             'r',
         )
         self.assertEqual(subjob.atoms[0].exit_code, 1)

--- a/test/unit/master/test_build_artifact.py
+++ b/test/unit/master/test_build_artifact.py
@@ -1,0 +1,34 @@
+from genty import genty, genty_dataset
+from os.path import expanduser, join
+
+from app.master.build_artifact import BuildArtifact
+from app.util.conf.configuration import Configuration
+from test.framework.base_unit_test_case import BaseUnitTestCase
+
+@genty
+class TestBuildArtifact(BaseUnitTestCase):
+    def setUp(self):
+        super().setUp()
+        Configuration['artifact_directory'] = expanduser('~')
+
+    @genty_dataset(
+        happy_path_all_args=(join(expanduser('~'), '1', 'artifact_2_3'), 1, 2, 3),
+        override_result_root=(join('override', '1', 'artifact_2_3'), 1, 2, 3, join('override')),
+        just_build_directory=(join(expanduser('~'), '1'), 1, None, None),
+        build_directory_with_override=(join('override', '1'), 1, None, None, join('override')),
+    )
+    def test_artifact_directory_returns_proper_artifact_path(self, expected_path, build_id, subjob_id=None,
+                                                             atom_id=None, result_root=None):
+        self.assertEquals(
+            expected_path,
+            BuildArtifact._artifact_directory(build_id, subjob_id, atom_id, result_root=result_root),
+            'The generated artifact directory is incorrect.'
+        )
+
+    @genty_dataset(
+        subjob_no_atom=(1, None),
+        atom_no_subjob=(None, 1),
+    )
+    def test_artifact_directory_raises_value_error_if_subjob_id_or_atom_id_specified(self, subjob_id, atom_id):
+        with self.assertRaises(ValueError):
+            BuildArtifact._artifact_directory(1, subjob_id, atom_id)

--- a/test/unit/slave/test_cluster_slave.py
+++ b/test/unit/slave/test_cluster_slave.py
@@ -39,7 +39,7 @@ class TestClusterSlave(BaseUnitTestCase):
         incorrect_build_id = 300
 
         with self.assertRaises(BadRequestError, msg='Start subjob should raise error if incorrect build_id specified.'):
-            slave.start_working_on_subjob(incorrect_build_id, 1, '~/test', ['ls'])
+            slave.start_working_on_subjob(incorrect_build_id, 1, ['ls'])
 
     @genty_dataset(
         current_build_id_not_set=(None,),
@@ -124,8 +124,7 @@ class TestClusterSlave(BaseUnitTestCase):
         self.assertTrue(setup_done_event.wait(timeout=5), 'Setup code under test should put to expected idle '
                                                           'url very quickly.')
 
-        slave.start_working_on_subjob(build_id=123, subjob_id=321,
-                                      subjob_artifact_dir='', atomic_commands=[])
+        slave.start_working_on_subjob(build_id=123, subjob_id=321, atomic_commands=[])
         # The timeout for this wait() is arbitrary, but it should be generous so the test isn't flaky on slow machines.
         self.assertTrue(subjob_done_event.wait(timeout=5), 'Subjob execution code under test should post to expected '
                                                            'results url very quickly.')
@@ -234,10 +233,9 @@ class TestClusterSlave(BaseUnitTestCase):
         slave._idle_executors = Mock()
 
         with patch.object(builtins, 'open', mock_open(read_data='asdf')):
-            slave._execute_subjob(build_id=1, subjob_id=2, executor=executor, subjob_artifact_dir='',
-                                  atomic_commands=[])
+            slave._execute_subjob(build_id=1, subjob_id=2, executor=executor, atomic_commands=[])
 
-        executor.execute_subjob.assert_called_with(1, 2, '', [], 12)
+        executor.execute_subjob.assert_called_with(1, 2, [], 12)
 
     def _create_cluster_slave(self, **kwargs):
         """

--- a/test/unit/slave/test_subjob_executor.py
+++ b/test/unit/slave/test_subjob_executor.py
@@ -1,6 +1,8 @@
 from unittest.mock import Mock, mock_open
+from os.path import expanduser, join
 
 from app.slave.subjob_executor import SubjobExecutor
+from app.util.conf.configuration import Configuration
 from test.framework.base_unit_test_case import BaseUnitTestCase
 
 
@@ -35,6 +37,7 @@ class TestSubjobExecutor(BaseUnitTestCase):
         executor._project_type.run_job_config_setup.assert_called_with()
 
     def test_execute_subjob_passes_correct_build_executor_index_to_execute_command_in_project(self):
+        Configuration['artifact_directory'] = expanduser('~')
         executor = SubjobExecutor(1)
         executor._project_type = Mock()
         executor._project_type.execute_command_in_project = Mock(return_value=(1, 2))
@@ -47,14 +50,14 @@ class TestSubjobExecutor(BaseUnitTestCase):
         atomic_commands = ['command']
         executor.id = 2
         expected_env_vars = {
-            'ARTIFACT_DIR': 'path',
+            'ARTIFACT_DIR': join(expanduser('~'), '1', 'artifact_2_0'),
             'ATOM_ID': 0,
             'EXECUTOR_INDEX': 2,
             'MACHINE_EXECUTOR_INDEX': 2,
             'BUILD_EXECUTOR_INDEX': 8
         }
 
-        executor.execute_subjob(build_id=1, subjob_id=2, subjob_artifact_dir='dir', atomic_commands=atomic_commands,
+        executor.execute_subjob(build_id=1, subjob_id=2, atomic_commands=atomic_commands,
                                 base_executor_index=6)
 
         executor._project_type.execute_command_in_project.assert_called_with('command', expected_env_vars,


### PR DESCRIPTION
Right now we perform artifact/result directory calculations, and each time we re-implement some form of os.path.join(). This commit consolidates the disparate methods into a single static function attached to the BuildArtifact class.