### PR TITLE
Call Popen with a cmd sequence instead of command string

### DIFF
--- a/app/client/service_runner.py
+++ b/app/client/service_runner.py
@@ -34,9 +34,7 @@ class ServiceRunner(object):
         self._logger.info('Running master on {}'.format(self._master_url))
         if self.is_master_up():
             return
-        cmd = '{} master --port {} &'.format(
-            self._main_executable,
-            self._port(self._master_url))
+        cmd = [self._main_executable, 'master', '--port', self._port(self._master_url)]
 
         self._run_service(cmd, self._master_url)
 
@@ -56,12 +54,10 @@ class ServiceRunner(object):
         :return:
         """
         self._logger.info('Running slave')
-        cmd = '{} slave --master-url {} '.format(
-            self._main_executable,
-            self._master_url)
+        cmd = [self._main_executable, 'slave', '--master-url', self._master_url]
         if port is not None:
-            cmd += '--port {} '.format(str(port))
-        cmd += '&'
+            cmd.extend(['--port', str(port)])
+
         self._run_service(cmd)
 
     def block_until_build_queue_empty(self, timeout=60):
@@ -88,7 +84,7 @@ class ServiceRunner(object):
             raise Exception('Master service did not become idle before timeout.')
 
     def kill(self):
-        self._run_service('{} stop'.format(self._main_executable))
+        self._run_service([self._main_executable, 'stop'])
 
     def _run_service(self, cmd, service_url=None):
         """
@@ -97,9 +93,10 @@ class ServiceRunner(object):
         :param cmd: shell command for running the service as a background process
         :return:
         """
+        print('running cmd: {}'.format(cmd))
         if service_url is not None and self.is_up(service_url):
             return
-        Popen_with_delayed_expansion(cmd, stdout=DEVNULL, shell=True)
+        Popen_with_delayed_expansion(cmd, stdout=DEVNULL)
         if service_url is not None and not self.is_up(service_url, timeout=10):
             raise ServiceRunError("Failed to run service on {}.".format(service_url))
 

--- a/test/unit/client/test_service_runner.py
+++ b/test/unit/client/test_service_runner.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock
+from unittest.mock import Mock, call, ANY
 
 from app.client.service_runner import ServiceRunner, ServiceRunError
 from test.framework.base_unit_test_case import BaseUnitTestCase
@@ -22,7 +22,7 @@ class TestServiceRunner(BaseUnitTestCase):
         except ServiceRunError:
             pass
 
-        assert self.mock_Popen.called
+        self.assertEqual(call([ANY, 'master', '--port', '1'], stdout=ANY), self.mock_Popen.call_args)
 
     def test_run_master_does_not_invoke_popen_if_resp_is_ok(self):
         mock_network = self.mock_Network.return_value
@@ -33,4 +33,4 @@ class TestServiceRunner(BaseUnitTestCase):
         except ServiceRunError:
             pass
 
-        assert  not self.mock_Popen.called
+        assert not self.mock_Popen.called


### PR DESCRIPTION
According to https://docs.python.org/3.4/library/subprocess.html#popen-constructor, this is the recommanded way to make cross-platform Popen objects. The way we used to pass command strings to Popen doesn't work well on Windows if the command includes spaces.