### PR TITLE
Add slave to subjob API response

### DIFF
--- a/app/master/subjob.py
+++ b/app/master/subjob.py
@@ -64,7 +64,8 @@ class Subjob(object):
         return {
             'id': self._subjob_id,
             'command': self.job_config.command,
-            'atoms': self.get_atoms()
+            'atoms': self.get_atoms(),
+            'slave': self.slave.url if self.slave else None,
         }
 
     @property

--- a/test/unit/master/test_subjob.py
+++ b/test/unit/master/test_subjob.py
@@ -43,6 +43,7 @@ class TestSubjob(BaseUnitTestCase):
         expected_api_repr = {
             'id': 34,
             'command': self._job_config_command,
+            'slave': None,
             'atoms': [
                 {
                     'id': 0,


### PR DESCRIPTION
Previously the only way to find out where a subjob ran was to grep
the master logs. This will let us skip that step.