### PR TITLE
Add appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,11 @@
+install:
+  - "SET PATH=C:\\Python34;C:\\Python34\\Scripts\\;%PATH%"
+  - pip install -r requirements.txt
+
+environment:
+  CR_VERBOSE: 1
+
+build: false  # Not a C# project
+
+test_script:
+  - nosetests -vv test

--- a/test/functional/test_cluster_basic.py
+++ b/test/functional/test_cluster_basic.py
@@ -28,8 +28,8 @@ class TestClusterBasic(BaseFunctionalTestCase):
             'project_directory': project_dir.name,
         })
         build_id = build_resp['build_id']
-        master.block_until_build_finished(build_id, timeout=10)
-        slave.block_until_idle(timeout=5)  # ensure slave teardown has finished before making assertions
+        master.block_until_build_finished(build_id, timeout=30)
+        slave.block_until_idle(timeout=20)  # ensure slave teardown has finished before making assertions
 
         if test_job_config.expected_to_fail:
             self.assert_build_has_failure_status(build_id=build_id)


### PR DESCRIPTION
As we've fixed all the tests of CR on Windows, adding appveyor to CI helps us prevent from regression.