### PR TITLE
Clean up test conf file in functional tests

### DIFF
--- a/test/framework/functional/functional_test_cluster.py
+++ b/test/framework/functional/functional_test_cluster.py
@@ -65,7 +65,8 @@ class FunctionalTestCluster(object):
         """
         # Copy default conf file to tmp location
         self._conf_template_path = join(self._clusterrunner_repo_dir, 'conf', 'default_clusterrunner.conf')
-        test_conf_file_path = tempfile.NamedTemporaryFile().name
+        # Create the conf file inside base dir so we can clean up the test at the end just by removing the base dir
+        test_conf_file_path = tempfile.NamedTemporaryFile(dir=base_dir_sys_path).name
         shutil.copy(self._conf_template_path, test_conf_file_path)
         os.chmod(test_conf_file_path, ConfigFile.CONFIG_FILE_MODE)
         conf_file = ConfigFile(test_conf_file_path)


### PR DESCRIPTION
Due to a previous commit (ade724c88271c420ad1082f451d2eb9fa21bc000), conf file created for function tests are not being cleanup. This change makes sure that the conf file created will live inside the temp base directory which will be cleanup after each test.