### PR TITLE
Display the atom, not atom command, in api representation.

### DIFF
--- a/app/master/atom.py
+++ b/app/master/atom.py
@@ -28,11 +28,11 @@ class Atom(object):
         :type state: `:class:AtomState` | None
         """
         self._env_var_name = env_var_name
-        self._atom_value = atom_value
+        self.atom_value = atom_value
         self.expected_time = expected_time
         self.actual_time = actual_time
         self.exit_code = exit_code
         self.state = state
 
         # Convert atomizer command output into environment variable export commands.
-        self.command_string = get_environment_variable_setter_command(self._env_var_name, self._atom_value)
+        self.command_string = get_environment_variable_setter_command(self._env_var_name, self.atom_value)

--- a/app/master/subjob.py
+++ b/app/master/subjob.py
@@ -75,7 +75,7 @@ class Subjob(object):
     def get_atoms(self):
         return [{
             'id': idx,
-            'atom': atom.command_string,
+            'atom': atom.atom_value,
             'expected_time': atom.expected_time,
             'actual_time': atom.actual_time,
             'exit_code': atom.exit_code,

--- a/test/unit/master/test_subjob.py
+++ b/test/unit/master/test_subjob.py
@@ -2,10 +2,8 @@ from unittest.mock import Mock
 from app.master.atom import Atom
 from app.master.job_config import JobConfig
 
-from app.master.atom import AtomState
 from app.master.subjob import Subjob
 from app.project_type.project_type import ProjectType
-from app.util.process_utils import get_environment_variable_setter_command
 from test.framework.base_unit_test_case import BaseUnitTestCase
 
 
@@ -47,7 +45,7 @@ class TestSubjob(BaseUnitTestCase):
             'atoms': [
                 {
                     'id': 0,
-                    'atom': get_environment_variable_setter_command('BREAKFAST', 'pancakes'),
+                    'atom': 'pancakes',
                     'expected_time': 23.4,
                     'actual_time': 56.7,
                     'exit_code': 1,
@@ -55,7 +53,7 @@ class TestSubjob(BaseUnitTestCase):
                 },
                 {
                     'id': 1,
-                    'atom': get_environment_variable_setter_command('BREAKFAST', 'cereal'),
+                    'atom': 'cereal',
                     'expected_time': 89.0,
                     'actual_time': 24.6,
                     'exit_code': 0,


### PR DESCRIPTION
In displaying the streaming console output, the atom command is
difficult to read.

And as far as I can tell, we do not use the atom command (from the api
representation) anywhere.