### PR TITLE
Canceling a build should resolve slave statuses

### DIFF
--- a/app/subcommands/cancel_subcommand.py
+++ b/app/subcommands/cancel_subcommand.py
@@ -1,0 +1,28 @@
+from app.client.cluster_api_client import ClusterMasterAPIClient
+from app.subcommands.subcommand import Subcommand
+from app.util import log
+from app.util.conf.configuration import Configuration
+
+
+class CancelSubcommand(Subcommand):
+
+    def run(self, log_level, master_url, build_id, **request_params):
+        """
+        Execute a build and wait for it to complete.
+
+        :param log_level: the log level at which to do application logging (or None for default log level)
+        :type log_level: str | None
+        :param master_url: the url (specified by the user) of the master to which we should send the build
+        :type master_url: str | None
+        :param build_id: The build to cancel
+        :type build_id: int
+        :param request_params: key-value pairs to be provided as build parameters in the build request
+        :type request_params: dict
+        """
+        log_level = log_level or Configuration['log_level']
+        log.configure_logging(log_level=log_level, simplified_console_logs=True)
+
+        master_url = master_url or '{}:{}'.format(Configuration['hostname'], Configuration['port'])
+        client = ClusterMasterAPIClient(master_url)
+        client.cancel_build(build_id)
+

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ import threading
 import time
 
 from app.subcommands.build_subcommand import BuildSubcommand
+from app.subcommands.cancel_subcommand import CancelSubcommand
 from app.subcommands.deploy_subcommand import DeploySubcommand
 from app.subcommands.master_subcommand import MasterSubcommand
 from app.subcommands.shutdown_subcommand import ShutdownSubcommand
@@ -120,6 +121,19 @@ def _parse_args(args):
     _add_project_type_subparsers(build_parser)
     build_parser.set_defaults(subcommand_class=BuildSubcommand)
 
+    cancel_parser = subparsers.add_parser(
+        'cancel',
+        help='Cancel a running build', formatter_class=ClusterRunnerHelpFormatter
+    )
+    cancel_parser.add_argument(
+        '--build-id',
+        help='The id of the build to cancel'
+    )
+    cancel_parser.add_argument(
+        '--master-url',
+        help='The url of the ClusterRunner master that is executing this build.'
+    )
+    cancel_parser.set_defaults(subcommand_class=CancelSubcommand)
 
     shutdown_parser = subparsers.add_parser(
         'shutdown',
@@ -145,7 +159,7 @@ def _parse_args(args):
 
     shutdown_parser.set_defaults(subcommand_class=ShutdownSubcommand)
 
-    for subparser in (master_parser, slave_parser, build_parser, stop_parser, deploy_parser, shutdown_parser):
+    for subparser in (master_parser, slave_parser, build_parser, stop_parser, deploy_parser, shutdown_parser, cancel_parser):
         subparser.add_argument(
             '-v', '--verbose',
             action='store_const', const='DEBUG', dest='log_level', help='set the log level to "debug"')


### PR DESCRIPTION
Currently if you cancel a build which has slaves allocated,
the build will be terminated but the slaves will remain allocated.
This deallocates all slaves attached to the build.

We also add locking around build preparation and canceling to
avoid race conditions.

Added a cancel subcommand.