### PR TITLE
Generate session id in cluster master, and return in every response.

### DIFF
--- a/app/util/exceptions.py
+++ b/app/util/exceptions.py
@@ -27,3 +27,11 @@ class ItemNotFoundError(Exception):
     An exception to represent the case where something was not found. Example: trying to get the status for a
     non-existent build. The web framework should translate this exception to a 404 response.
     """
+
+
+class PreconditionFailedError(Exception):
+    """
+    An exception to represent the case when a non-authentication-related precondition for accessing the resource
+    was not met. For example, the session id token has expired. The web framework should translate this exception
+    to a 412 response.
+    """

--- a/app/util/session_id.py
+++ b/app/util/session_id.py
@@ -1,0 +1,16 @@
+import uuid
+
+
+class SessionId(object):
+    SESSION_HEADER_KEY = 'Session-Id'
+    _session_id = None
+
+    @classmethod
+    def get(cls):
+        """
+        :return: the unique, generated session id string.
+        :rtype: str
+        """
+        if cls._session_id is None:
+            cls._session_id = str(uuid.uuid4())
+        return cls._session_id

--- a/app/web_framework/cluster_base_handler.py
+++ b/app/web_framework/cluster_base_handler.py
@@ -5,7 +5,7 @@ import tornado.web
 
 from app.util import log
 from app.util.conf.configuration import Configuration
-from app.util.exceptions import AuthenticationError, BadRequestError, ItemNotFoundError, ItemNotReadyError
+from app.util.exceptions import AuthenticationError, BadRequestError, ItemNotFoundError, ItemNotReadyError, PreconditionFailedError
 from app.util.network import ENCODED_BODY
 
 
@@ -23,6 +23,7 @@ class ClusterBaseHandler(tornado.web.RequestHandler):
         BadRequestError: http.client.BAD_REQUEST,
         AuthenticationError: http.client.UNAUTHORIZED,
         ItemNotFoundError: http.client.NOT_FOUND,
+        PreconditionFailedError: http.client.PRECONDITION_FAILED,
     }
 
     def _handle_request_exception(self, ex):

--- a/test/unit/util/test_session_id.py
+++ b/test/unit/util/test_session_id.py
@@ -1,0 +1,8 @@
+from test.framework.base_unit_test_case import BaseUnitTestCase
+from app.util.session_id import SessionId
+
+
+class TestSessionId(BaseUnitTestCase):
+    def test_get_should_return_same_string_on_repeated_calls(self):
+        session_id = SessionId.get()
+        self.assertEquals(session_id, SessionId.get())


### PR DESCRIPTION
Additionally, if the session id is specified in the header then enforce that it matches the current session id. If not, return a 404.