### PR TITLE
Replace directory path in atoms with the environment variable

### DIFF
--- a/app/master/atomizer.py
+++ b/app/master/atomizer.py
@@ -35,7 +35,9 @@ class Atomizer(object):
                                        '\n{}', atomizer_command, atomizer_var_name, exit_code, atomizer_output)
                     raise AtomizerError('Atomizer command failed!')
 
-                new_atoms = [Atom(atomizer_var_name, atom_value)
+                # For purposes of matching atom string values across builds, we must replace the generated/unique
+                # project directory with its corresponding universal environment variable: '$PROJECT_DIR'.
+                new_atoms = [Atom(atomizer_var_name, atom_value.replace(project_type.project_directory, '$PROJECT_DIR'))
                              for atom_value in atomizer_output.strip().splitlines()]
                 atoms_list.extend(new_atoms)
 

--- a/app/master/subjob.py
+++ b/app/master/subjob.py
@@ -129,12 +129,8 @@ class Subjob(object):
             timings_file_path = os.path.join(artifact_dir, BuildArtifact.TIMING_FILE)
             if os.path.exists(timings_file_path):
                 with open(timings_file_path, 'r') as f:
-                    # Strip out the project directory from atom timing data in order to have all
-                    # atom timing data be relative and project directory agnostic (the project
-                    # directory will be a generated unique path for every build).
-                    atom_key = atom.command_string.replace(self.project_type.project_directory, '')
                     atom.actual_time = float(f.readline())
-                    timings[atom_key] = atom.actual_time
+                    timings[atom.command_string] = atom.actual_time
             else:
                 self._logger.warning('No timing data for subjob {} atom {}.',
                                      self._subjob_id, atom_id)

--- a/app/master/time_based_atom_grouper.py
+++ b/app/master/time_based_atom_grouper.py
@@ -122,15 +122,11 @@ class TimeBasedAtomGrouper(object):
 
         # Generate list for atoms that have timing data
         for new_atom in new_atoms:
-            new_atom_directory_stripped = new_atom.command_string.replace(project_directory, '')
-
-            # When matching up new atoms with stored atom timing data, we use the project-directory-stripped
-            # atom string for matching.
-            if new_atom_directory_stripped not in old_atoms_with_times:
+            if new_atom.command_string not in old_atoms_with_times:
                 atoms_without_timing_data.append(new_atom)
                 continue
 
-            new_atom.expected_time = old_atoms_with_times[new_atom_directory_stripped]
+            new_atom.expected_time = old_atoms_with_times[new_atom.command_string]
 
             # Discover largest single atom time to use as conservative estimates for atoms with unknown times
             if max_atom_time < new_atom.expected_time:

--- a/test/unit/master/test_atomizer.py
+++ b/test/unit/master/test_atomizer.py
@@ -1,37 +1,37 @@
-from unittest.mock import MagicMock
+from unittest.mock import Mock
 from app.master.atomizer import Atomizer, AtomizerError
 
-from app.project_type.project_type import ProjectType
 from app.util.process_utils import get_environment_variable_setter_command
 from test.framework.base_unit_test_case import BaseUnitTestCase
 
 
 _FAKE_ATOMIZER_COMMAND = 'find . -name test_*.py'
-_FAKE_ATOMIZER_COMMAND_OUTPUT = 'test_a.py\ntest_b.py\ntest_c.py\n'
+_FAKE_ATOMIZER_COMMAND_OUTPUT = '/tmp/test/directory/test_a.py\n/tmp/test/directory/test_b.py\n/tmp/test/directory/test_c.py\n'
 _SUCCESSFUL_EXIT_CODE = 0
 _FAILING_EXIT_CODE = 1
 
 
 class TestAtomizer(BaseUnitTestCase):
     def test_atomizer_returns_expected_atom_list(self):
-        mock_project = MagicMock(spec_set=ProjectType)
+        mock_project = Mock()
         mock_project.execute_command_in_project.return_value = (_FAKE_ATOMIZER_COMMAND_OUTPUT, _SUCCESSFUL_EXIT_CODE)
+        mock_project.project_directory = '/tmp/test/directory'
 
         atomizer = Atomizer([{'TEST_FILE': _FAKE_ATOMIZER_COMMAND}])
         actual_atoms = atomizer.atomize_in_project(mock_project)
         actual_atom_commands = [atom.command_string for atom in actual_atoms]
 
         expected_atom_commands = [
-            get_environment_variable_setter_command('TEST_FILE', 'test_a.py'),
-            get_environment_variable_setter_command('TEST_FILE', 'test_b.py'),
-            get_environment_variable_setter_command('TEST_FILE', 'test_c.py'),
+            get_environment_variable_setter_command('TEST_FILE', '$PROJECT_DIR/test_a.py'),
+            get_environment_variable_setter_command('TEST_FILE', '$PROJECT_DIR/test_b.py'),
+            get_environment_variable_setter_command('TEST_FILE', '$PROJECT_DIR/test_c.py'),
         ]
         self.assertListEqual(expected_atom_commands, actual_atom_commands,
                              'List of actual atoms should match list of expected atoms.')
         mock_project.execute_command_in_project.assert_called_once_with(_FAKE_ATOMIZER_COMMAND)
 
     def test_atomizer_raises_exception_when_atomize_command_fails(self):
-        mock_project = MagicMock(spec_set=ProjectType)
+        mock_project = Mock()
         mock_project.execute_command_in_project.return_value = ('ERROR ERROR ERROR', _FAILING_EXIT_CODE)
 
         atomizer = Atomizer([{'TEST_FILE': _FAKE_ATOMIZER_COMMAND}])


### PR DESCRIPTION
This way, when viewing the atom commands in the API (among other places), you will see $PROJECT_DIR/test/path.php instead of /tmp/clusterrunner/blahblahgarbage/test/path.php.