### PR TITLE
Update timing data keys, not overwrite the file entirely.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
 # each line defined in env will create a new parallel test job on Travis
 env:
   - TARGETS="lint test-unit-with-coverage"
+  - TARGETS="test-integration-with-coverage"
   - TARGETS="test-functional test-unit-via-clusterrunner"
 
 install:

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,11 @@ test-unit:
 
 test-unit-with-coverage:
 	$(call print_msg, Running unit tests with coverage... )
-	nosetests -v --with-xcoverage --cover-package=app test/unit test/integration
+	nosetests -v --with-xcoverage --cover-package=app test/unit
+
+test-integration-with-coverage:
+	$(call print_msg, Running unit tests with coverage... )
+	nosetests -v --with-xcoverage --cover-package=app test/integration
 
 test-unit-via-clusterrunner:
 	$(call print_msg, Running unit tests via ClusterRunner... )

--- a/test/integration/master/test_build_artifact.py
+++ b/test/integration/master/test_build_artifact.py
@@ -1,0 +1,35 @@
+from genty import genty, genty_dataset
+import json
+import os
+from tempfile import mkstemp
+
+import app.util.fs
+from app.master.build_artifact import BuildArtifact
+from test.framework.base_integration_test_case import BaseIntegrationTestCase
+
+
+@genty
+class TestBuildArtifact(BaseIntegrationTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._timing_file_fd, cls._timing_file_path = mkstemp()
+
+    @classmethod
+    def tearDownClass(cls):
+        os.close(cls._timing_file_fd)
+        os.remove(cls._timing_file_path)
+
+    @genty_dataset(
+        mutually_exclusive=({'1': 1, '2': 2}, {'3': 3}, {'1': 1, '2': 2, '3': 3}),
+        entire_overlap=({'1': 1, '2': 2}, {'1': 3, '2': 4}, {'1': 3, '2': 4}),
+        some_overlap=({'1': 1, '2': 2}, {'2': 4, '3': 5}, {'1': 1, '2': 4, '3': 5}),
+    )
+    def test_update_timing_file(self, existing_timing_data, new_timing_data, expected_final_timing_data):
+        app.util.fs.write_file(json.dumps(existing_timing_data), self._timing_file_path)
+        build_artifact = BuildArtifact('/some/dir/doesnt/matter')
+        build_artifact._update_timing_file(self._timing_file_path, new_timing_data)
+
+        with open(self._timing_file_path, 'r') as timing_file:
+            updated_timing_data = json.load(timing_file)
+
+        self.assertDictEqual(updated_timing_data, expected_final_timing_data)

--- a/test/unit/master/test_atomizer.py
+++ b/test/unit/master/test_atomizer.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock
-from app.master.atomizer import Atomizer, AtomizerError
 
+from app.master.atomizer import Atomizer, AtomizerError
+from app.project_type.project_type import ProjectType
 from app.util.process_utils import get_environment_variable_setter_command
 from test.framework.base_unit_test_case import BaseUnitTestCase
 
@@ -13,7 +14,7 @@ _FAILING_EXIT_CODE = 1
 
 class TestAtomizer(BaseUnitTestCase):
     def test_atomizer_returns_expected_atom_list(self):
-        mock_project = Mock()
+        mock_project = Mock(spec=ProjectType)
         mock_project.execute_command_in_project.return_value = (_FAKE_ATOMIZER_COMMAND_OUTPUT, _SUCCESSFUL_EXIT_CODE)
         mock_project.project_directory = '/tmp/test/directory'
 
@@ -31,7 +32,7 @@ class TestAtomizer(BaseUnitTestCase):
         mock_project.execute_command_in_project.assert_called_once_with(_FAKE_ATOMIZER_COMMAND)
 
     def test_atomizer_raises_exception_when_atomize_command_fails(self):
-        mock_project = Mock()
+        mock_project = Mock(spec=ProjectType)
         mock_project.execute_command_in_project.return_value = ('ERROR ERROR ERROR', _FAILING_EXIT_CODE)
 
         atomizer = Atomizer([{'TEST_FILE': _FAKE_ATOMIZER_COMMAND}])


### PR DESCRIPTION
This will be necessary when we implement overridden atoms from build
requests. In such a build request, we will not have ran all the atoms,
and if we were to keep the existing behavior, we would wipe out all of
the atom timing data except for the select few that were manually
specified in the build request.

This method also leaves the door open in the future if we want to always
update the timing data, regardless of overall build success/failure, but
only for successful atoms.