### PR TITLE
Support atom overrides in builds/ POST endpoint.

### DIFF
--- a/app/master/atom.py
+++ b/app/master/atom.py
@@ -1,7 +1,5 @@
 from enum import Enum
 
-from app.util.process_utils import get_environment_variable_setter_command
-
 
 class AtomState(str, Enum):
     NOT_STARTED = 'NOT_STARTED'
@@ -12,27 +10,21 @@ class AtomState(str, Enum):
 class Atom(object):
     def __init__(
             self,
-            env_var_name,
-            atom_value,
+            command_string,
             expected_time=None,
             actual_time=None,
             exit_code=None,
             state=None,
     ):
         """
-        :type env_var_name: str
-        :type atom_value: str
+        :type command_string: str
         :type expected_time: float | None
         :type actual_time: float | None
         :type exit_code: int | None
         :type state: `:class:AtomState` | None
         """
-        self._env_var_name = env_var_name
-        self.atom_value = atom_value
+        self.command_string = command_string
         self.expected_time = expected_time
         self.actual_time = actual_time
         self.exit_code = exit_code
         self.state = state
-
-        # Convert atomizer command output into environment variable export commands.
-        self.command_string = get_environment_variable_setter_command(self._env_var_name, self.atom_value)

--- a/app/master/atomizer.py
+++ b/app/master/atomizer.py
@@ -1,5 +1,6 @@
 from app.master.atom import Atom
 from app.util import log
+from app.util.process_utils import get_environment_variable_setter_command
 
 
 class Atomizer(object):
@@ -35,10 +36,12 @@ class Atomizer(object):
                                        '\n{}', atomizer_command, atomizer_var_name, exit_code, atomizer_output)
                     raise AtomizerError('Atomizer command failed!')
 
-                # For purposes of matching atom string values across builds, we must replace the generated/unique
-                # project directory with its corresponding universal environment variable: '$PROJECT_DIR'.
-                new_atoms = [Atom(atomizer_var_name, atom_value.replace(project_type.project_directory, '$PROJECT_DIR'))
-                             for atom_value in atomizer_output.strip().splitlines()]
+                new_atoms = []
+                for atom_value in atomizer_output.strip().splitlines():
+                    # For purposes of matching atom string values across builds, we must replace the generated/unique
+                    # project directory with its corresponding universal environment variable: '$PROJECT_DIR'.
+                    atom_value = atom_value.replace(project_type.project_directory, '$PROJECT_DIR')
+                    new_atoms.append(Atom(get_environment_variable_setter_command(atomizer_var_name, atom_value)))
                 atoms_list.extend(new_atoms)
 
         return atoms_list

--- a/app/master/build_request.py
+++ b/app/master/build_request.py
@@ -1,46 +1,35 @@
-"""
-This class is a data object for the build request parameters provided by the user. It additionally provides
-validation.
-
-A requirement with the request that it must be able to specify where the cluster runner configuration file
-is going to live (clusterrunner.yaml). The cluster runner will look in the top level project directory
-for this file. If it doesn't exist, it is a fatal error and the build will be immediately aborted.
-
-The only field that is consistently required for ALL types is the "type" field.
-
-Possible formats of valid incoming build requests:
-
-Git repo:
-{
-    "type": "repo",
-    "repo": "http://dduke:password1234@github.com/drobertduke/some-project",
-    [OPTIONAL] "hash": "123456789123456789123456789"
-}
-
-Adhoc (arbitrary shell commands):
-{
-    "type": "adhoc",
-    "commands": [
-        "cd /box/www/current",
-        "git fetch scm",
-        "git reset --hard 123456789123456789123456789"
-    ],
-    "project_directory": "/box/www/current"
-}
-"""
-
 from app.util import util
 
 
 class BuildRequest(object):
+    """
+    This class is a data object for the build request parameters provided by the user. It additionally provides
+    validation.
 
+    A requirement with the request that it must be able to specify where the cluster runner configuration file
+    is going to live (clusterrunner.yaml). The cluster runner will look in the top level project directory
+    for this file. If it doesn't exist, it is a fatal error and the build will be immediately aborted.
+
+    The only field that is consistently required for ALL types is the "type" field.
+
+    Currently we only support the 'git' project type.
+
+    Git repo:
+    {
+        "type": "git",
+        "url": "ssh://github.com/drobertduke/some-project",
+        "branch": "master",
+        "job_name": "clusterrunner_configured_job",
+        [OPTIONAL] "atoms_override": ['export VAR="overridden_atom_value_1";', ...],
+        [OPTIONAL] "hash": "123456789123456789123456789"
+    }
+    """
     def __init__(self, build_parameters):
         """
         :param build_parameters: A dictionary of request parameters
         :type build_parameters: dict[str, str]
         """
         self._build_parameters = dict(build_parameters) or {}
-
         build_type = self._build_parameters.get('type')
         self._build_type = build_type.lower() if build_type else None
 

--- a/app/master/build_request_handler.py
+++ b/app/master/build_request_handler.py
@@ -3,6 +3,7 @@ import os
 from queue import Queue
 from threading import Lock
 
+from app.master.atom import Atom
 from app.master.atom_grouper import AtomGrouper
 from app.master.build_request import BuildRequest
 from app.master.subjob import Subjob
@@ -148,7 +149,13 @@ class BuildRequestHandler(object):
         :type project_type: project_type.project_type.ProjectType
         :rtype: list[Subjob]
         """
-        atoms_list = job_config.atomizer.atomize_in_project(project_type)
+        # Users can override the list of atoms to be run in this build. If the atoms_override
+        # was specified, we can skip the atomization step and use those overridden atoms instead.
+        if project_type.atoms_override is not None:
+            atoms_string_list = project_type.atoms_override
+            atoms_list = [Atom(atom_string_value) for atom_string_value in atoms_string_list]
+        else:
+            atoms_list = job_config.atomizer.atomize_in_project(project_type)
 
         # Group the atoms together using some grouping strategy
         timing_file_path = project_type.timing_file_path(job_config.name)

--- a/app/master/subjob.py
+++ b/app/master/subjob.py
@@ -75,7 +75,7 @@ class Subjob(object):
     def get_atoms(self):
         return [{
             'id': idx,
-            'atom': atom.atom_value,
+            'atom': atom.command_string,
             'expected_time': atom.expected_time,
             'actual_time': atom.actual_time,
             'exit_code': atom.exit_code,

--- a/app/project_type/git.py
+++ b/app/project_type/git.py
@@ -70,14 +70,13 @@ class Git(ProjectType):
         :return: A path for storing timing files
         :rtype: str
         """
-
         return Git._generate_path_from_repo_url(Configuration['timings_directory'], url)
 
     # pylint: disable=redefined-builtin
     # Disable "redefined-builtin" because renaming the "hash" parameter would be a breaking change.
     # todo: Deprecate the "branch" parameter and create a new one named "ref" to replace it.
     def __init__(self, url, build_project_directory='', project_directory='', remote='origin', branch='master',
-                 hash='FETCH_HEAD', config=None, job_name=None, remote_files=None):
+                 hash='FETCH_HEAD', config=None, job_name=None, remote_files=None, atoms_override=None):
         """
         Note: the first line of each parameter docstring will be exposed as command line argument documentation for the
         clusterrunner build client.
@@ -100,8 +99,10 @@ class Git(ProjectType):
         :type job_name: list [str] | None
         :param remote_files: dictionary mapping of output file to URL
         :type remote_files: dict[str, str] | None
+        :param atoms_override: The list of overridden atoms (if specified, will not run atomizer).
+        :type atoms_override: list[str] | None
         """
-        super().__init__(config, job_name, remote_files)
+        super().__init__(config, job_name, remote_files, atoms_override)
         self._url = url
         self._remote = remote
         self._branch = branch

--- a/app/project_type/project_type.py
+++ b/app/project_type/project_type.py
@@ -16,21 +16,34 @@ from app.util.process_utils import Popen_with_delayed_expansion, get_environment
 
 class ProjectType(object):
 
-    def __init__(self, config=None, job_name=None, remote_files=None):
+    def __init__(self, config=None, job_name=None, remote_files=None, atoms_override=None):
         """
         :param config: A yaml string representing a clusterrunner.yaml file
         :type config: str | None
         :type job_name: str | None
         :param remote_files: key-value pairs of where the key is the output_file and the value is the url
         :type remote_files: dict[str, str] | None
+        :param atoms_override: the list of overriden atoms specified from the build request. If this parameter
+            is specified, then the atomization step is skipped.
+        :type atoms_override: list[str]
         """
         self.project_directory = ''
+        self._atoms_override = atoms_override
         self._config = config
         self._job_name = job_name
         self._remote_files = remote_files if remote_files else {}
-
         self._logger = log.get_logger(__name__)
         self._kill_event = Event()
+
+    @property
+    def atoms_override(self):
+        """
+        :return: The list of atom command strings that were specified in the build request. This is an optional
+            build request parameter that is defaulted to 'None', in which case atomization still occurs during
+            build preparation.
+        :rtype: list[str]|None
+        """
+        return self._atoms_override
 
     @property
     def job_name(self):

--- a/test/unit/master/test_build_request_handler.py
+++ b/test/unit/master/test_build_request_handler.py
@@ -1,0 +1,41 @@
+from genty import genty, genty_dataset
+from unittest.mock import Mock
+
+from app.project_type.project_type import ProjectType
+from app.master.atom import Atom
+from app.master.build_request_handler import BuildRequestHandler
+from app.master.atomizer import Atomizer
+from app.master.job_config import JobConfig
+from test.framework.base_unit_test_case import BaseUnitTestCase
+
+
+@genty
+class TestBuildRequestHandler(BaseUnitTestCase):
+    @genty_dataset(
+        atoms_override_specified=(['override1', 'override2'], None, False),
+        atoms_override_not_specified=(None, [Atom('atom_value_1'), Atom('atom_value_2')], True),
+    )
+    def test_compute_subjobs_for_build_only_atomizes_if_override_not_specified(self, atoms_override, atomizer_output,
+                                                                               atomizer_called):
+        """
+        :type atoms_override: list[str] | None
+        :type atomizer_output: list[Atom] | None
+        :type atomizer_called: bool
+        """
+        self.patch('os.path.isfile').return_value = False
+        mock_project = Mock(spec=ProjectType)
+        mock_project.atoms_override = atoms_override
+        mock_project.timing_file_path.return_value = '/some/path/doesnt/matter'
+        mock_project.project_directory = '/some/project/directory'
+        mock_atomizer = Mock(spec=Atomizer)
+        mock_atomizer.atomize_in_project.return_value = atomizer_output
+        mock_job_config = Mock(spec=JobConfig)
+        mock_job_config.name = 'some_config'
+        mock_job_config.max_executors = 1
+        mock_job_config.atomizer = mock_atomizer
+        build_request_handler = BuildRequestHandler()
+
+        build_request_handler._compute_subjobs_for_build(build_id=1, job_config=mock_job_config,
+                                                         project_type=mock_project)
+
+        self.assertEquals(mock_atomizer.atomize_in_project.called, atomizer_called)

--- a/test/unit/master/test_subjob.py
+++ b/test/unit/master/test_subjob.py
@@ -19,15 +19,13 @@ class TestSubjob(BaseUnitTestCase):
             job_config=Mock(spec=JobConfig, command=self._job_config_command),
             atoms=[
                 Atom(
-                    'BREAKFAST',
-                    'pancakes',
+                    'export BREAKFAST="pancakes";',
                     expected_time=23.4,
                     actual_time=56.7,
                     exit_code=1,
                 ),
                 Atom(
-                    'BREAKFAST',
-                    'cereal',
+                    'export BREAKFAST="cereal";',
                     expected_time=89.0,
                     actual_time=24.6,
                     exit_code=0,
@@ -45,7 +43,7 @@ class TestSubjob(BaseUnitTestCase):
             'atoms': [
                 {
                     'id': 0,
-                    'atom': 'pancakes',
+                    'atom': 'export BREAKFAST="pancakes";',
                     'expected_time': 23.4,
                     'actual_time': 56.7,
                     'exit_code': 1,
@@ -53,7 +51,7 @@ class TestSubjob(BaseUnitTestCase):
                 },
                 {
                     'id': 1,
-                    'atom': 'cereal',
+                    'atom': 'export BREAKFAST="cereal";',
                     'expected_time': 89.0,
                     'actual_time': 24.6,
                     'exit_code': 0,


### PR DESCRIPTION
If the atom_overrides build parameter is specified in the API request, the 'atomizer' section of the clusterrunner.yaml config gets bypassed.

Having this parameter be specified allows us to re-run just failed atoms, for example.