### PR TITLE
Change 'failed_atoms' endpoint API representation for a build

### DIFF
--- a/app/master/atom.py
+++ b/app/master/atom.py
@@ -15,6 +15,7 @@ class Atom(object):
             actual_time=None,
             exit_code=None,
             state=None,
+            id=None
     ):
         """
         :type command_string: str
@@ -22,9 +23,21 @@ class Atom(object):
         :type actual_time: float | None
         :type exit_code: int | None
         :type state: `:class:AtomState` | None
+        :type id: int | None
         """
         self.command_string = command_string
         self.expected_time = expected_time
         self.actual_time = actual_time
         self.exit_code = exit_code
         self.state = state
+        self.id = id
+
+    def api_representation(self):
+        return {
+            'command_string': self.command_string,
+            'expected_time': self.expected_time,
+            'actual_time': self.actual_time,
+            'exit_code': self.exit_code,
+            'state': self.state,
+            'id': self.id,
+        }

--- a/app/master/build_artifact.py
+++ b/app/master/build_artifact.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 
 from app.util.conf.configuration import Configuration
 import app.util.fs
@@ -21,7 +22,8 @@ class BuildArtifact(object):
         """
         self._logger = get_logger(__name__)
         self.build_artifact_dir = build_artifact_dir
-        self._failed_commands = None
+        self._failed_artifact_directories = None
+        self._failed_subjob_atom_pairs = None
 
     def write_timing_data(self, timing_file_path, timing_data):
         """
@@ -49,43 +51,53 @@ class BuildArtifact(object):
 
         # If file exists, update the timing data only if there were no failures this build
         # @TODO: in the future we should always update the timing data, but only for passed atom keys.
-        if len(self.get_failed_commands()) == 0:
+        if len(self._get_failed_artifact_directories()) == 0:
             self._update_timing_file(timing_file_path, timing_data)
             self._logger.debug('Overwrote existing timing file in {}', timing_file_path)
             return
 
         self._logger.debug('Did not write/overwrite timing data during build')
 
-    def get_failed_commands(self):
+    def get_failed_subjob_and_atom_ids(self):
         """
-        :return: a dictionary of atom names (e.g. artifact_0_0) to failed commmands
-        :rtype dict of [str, str]
+        Get a list of (subjob_id, atom_id) tuples that failed.
+        :return: Returns a list of tuples with two integers.
+        :rtype: list[(int, int)]
         """
-        if self._failed_commands is None:
+        if self._failed_subjob_atom_pairs is None:
+            self._failed_subjob_atom_pairs = []
 
+            for failed_artifact_dir in self._get_failed_artifact_directories():
+                self._failed_subjob_atom_pairs.append(self._subjob_and_atom_ids(failed_artifact_dir))
+
+        return self._failed_subjob_atom_pairs
+
+    def _get_failed_artifact_directories(self):
+        """
+        :return: A list of build-artifact relative paths to the failed artifact directories (e.g. artifact_0_0).
+        :rtype list[str]
+        """
+        if self._failed_artifact_directories is None:
             if not os.path.isdir(self.build_artifact_dir):
                 message = 'Build artifact dir {} does not exist'.format(self.build_artifact_dir)
                 self._logger.error(message)
                 raise RuntimeError(message)
 
             # Find failed atoms in the artifact directory
-            self._failed_commands = {}
+            self._failed_artifact_directories = []
             for build_artifact_file_or_subdir in os.listdir(self.build_artifact_dir):
                 if self._is_atom_artifact_dir(build_artifact_file_or_subdir):
                     exit_file = os.path.join(self.build_artifact_dir, build_artifact_file_or_subdir,
                                              BuildArtifact.EXIT_CODE_FILE)
-                    command_file = os.path.join(self.build_artifact_dir, build_artifact_file_or_subdir,
-                                                BuildArtifact.COMMAND_FILE)
-                    if os.path.isfile(exit_file) and os.path.isfile(command_file):
-                        with open(exit_file, 'r') as exit_stream, open(command_file, 'r') as command_stream:
+                    if os.path.isfile(exit_file):
+                        with open(exit_file, 'r') as exit_stream:
                             exit_code = exit_stream.readline()
-                            command = command_stream.readline()
                             if int(exit_code) != 0:
-                                self._failed_commands[build_artifact_file_or_subdir] = command
+                                self._failed_artifact_directories.append(build_artifact_file_or_subdir)
                     else:
-                        self._logger.error("Missing clusterrunner artifacts for " + build_artifact_file_or_subdir)
+                        self._logger.error("Missing clusterrunner exit file for " + build_artifact_file_or_subdir)
 
-        return self._failed_commands
+        return self._failed_artifact_directories
 
     def _is_atom_artifact_dir(self, dir_basename):
         """
@@ -100,10 +112,10 @@ class BuildArtifact(object):
         """
         Only generate a failures.txt file if there were any failed commands for the build.
         """
-        failed_atoms = self.get_failed_commands()
-        if len(failed_atoms) > 0:
+        failed_atom_directories = self._get_failed_artifact_directories()
+        if len(failed_atom_directories) > 0:
             with open(os.path.join(self.build_artifact_dir, 'failures.txt'), 'w') as f:
-                f.write("\n".join(failed_atoms))
+                f.write("\n".join(failed_atom_directories))
 
     def _write_timing_data_to_file(self, timing_file_path, timing_data):
         """
@@ -177,3 +189,23 @@ class BuildArtifact(object):
             return os.path.join(result_root, str(build_id), BuildArtifact.ATOM_DIR_FORMAT.format(subjob_id, atom_id))
         else:
             raise ValueError('Specified one of either subjob_id or atom_id. Must either specify both or neither.')
+
+    @staticmethod
+    def _subjob_and_atom_ids(directory_name):
+        """
+        Infer the subjob and atom id's from an artifact directory name. This name should be of format:
+
+        "artifact_SubjobId_AtomId"
+
+        The method raises a ValueError if the directory_name does not match expected convention.
+
+        :type directory_name: str
+        :return: A tuple, with the first element being the subjob id, and the second element being the atom id.
+        :rtype: (int, int)
+        """
+        id_match = re.search(r'artifact_(\d*)_(\d*)$', directory_name)
+
+        if id_match is None:
+            raise ValueError('Artifact directory {} did not meet naming convention'.format(directory_name))
+
+        return int(id_match.group(1)), int(id_match.group(2))

--- a/app/master/subjob.py
+++ b/app/master/subjob.py
@@ -26,10 +26,12 @@ class Subjob(object):
         self._subjob_id = subjob_id
         self.project_type = project_type
         self.job_config = job_config
-        self._atoms = atoms
         self._set_atom_state(AtomState.NOT_STARTED)
         self.timings = {}  # a dict, atom_ids are the keys and seconds are the values
         self.slave = None  # The slave that had been assigned this subjob. Is None if not started.
+        self._atoms = atoms
+        for idx, atom in enumerate(self._atoms):
+            atom.id = idx
 
     def _set_atom_state(self, state):
         """
@@ -61,26 +63,20 @@ class Subjob(object):
         """
         :rtype: dict [str, str]
         """
+
         return {
             'id': self._subjob_id,
             'command': self.job_config.command,
-            'atoms': self.get_atoms(),
+            'atoms': [atom.api_representation() for atom in self._atoms],
             'slave': self.slave.url if self.slave else None,
         }
 
     @property
     def atoms(self):
+        """
+        :rtype: list[Atom]
+        """
         return self._atoms
-
-    def get_atoms(self):
-        return [{
-            'id': idx,
-            'atom': atom.command_string,
-            'expected_time': atom.expected_time,
-            'actual_time': atom.actual_time,
-            'exit_code': atom.exit_code,
-            'state': atom.state.value,
-        } for idx, atom in enumerate(self._atoms)]
 
     def build_id(self):
         """

--- a/app/web_framework/cluster_master_application.py
+++ b/app/web_framework/cluster_master_application.py
@@ -164,7 +164,7 @@ class _AtomsHandler(_ClusterMasterBaseAPIHandler):
         build = self._cluster_master.get_build(int(build_id))
         subjob = build.subjob(int(subjob_id))
         response = {
-            'atoms': subjob.get_atoms(),
+            'atoms': [atom.api_representation() for atom in subjob.atoms()],
         }
         self.write(response)
 
@@ -173,9 +173,9 @@ class _AtomHandler(_ClusterMasterBaseAPIHandler):
     def get(self, build_id, subjob_id, atom_id):
         build = self._cluster_master.get_build(int(build_id))
         subjob = build.subjob(int(subjob_id))
-        atoms = subjob.get_atoms()
+        atoms = subjob.atoms()
         response = {
-            'atom': atoms[int(atom_id)],
+            'atom': atoms[int(atom_id)].api_representation(),
         }
         self.write(response)
 

--- a/test/integration/master/test_build_artifact.py
+++ b/test/integration/master/test_build_artifact.py
@@ -1,9 +1,10 @@
 from genty import genty, genty_dataset
 import json
 import os
-from tempfile import mkstemp
+import shutil
+from tempfile import mkstemp, mkdtemp
 
-import app.util.fs
+from app.util import fs
 from app.master.build_artifact import BuildArtifact
 from test.framework.base_integration_test_case import BaseIntegrationTestCase
 
@@ -12,12 +13,21 @@ from test.framework.base_integration_test_case import BaseIntegrationTestCase
 class TestBuildArtifact(BaseIntegrationTestCase):
     @classmethod
     def setUpClass(cls):
+        # For timing file test
         cls._timing_file_fd, cls._timing_file_path = mkstemp()
+
+        # For parsing subjob/atom ids from build artifact test.
+        cls._artifact_directory_path = mkdtemp()
+        fs.write_file('0', os.path.join(cls._artifact_directory_path, 'artifact_1_0', 'clusterrunner_exit_code'))
+        fs.write_file('1', os.path.join(cls._artifact_directory_path, 'artifact_1_1', 'clusterrunner_exit_code'))
+        fs.write_file('0', os.path.join(cls._artifact_directory_path, 'artifact_2_0', 'clusterrunner_exit_code'))
+        fs.write_file('1', os.path.join(cls._artifact_directory_path, 'artifact_2_1', 'clusterrunner_exit_code'))
 
     @classmethod
     def tearDownClass(cls):
         os.close(cls._timing_file_fd)
         os.remove(cls._timing_file_path)
+        shutil.rmtree(cls._artifact_directory_path)
 
     @genty_dataset(
         mutually_exclusive=({'1': 1, '2': 2}, {'3': 3}, {'1': 1, '2': 2, '3': 3}),
@@ -25,7 +35,7 @@ class TestBuildArtifact(BaseIntegrationTestCase):
         some_overlap=({'1': 1, '2': 2}, {'2': 4, '3': 5}, {'1': 1, '2': 4, '3': 5}),
     )
     def test_update_timing_file(self, existing_timing_data, new_timing_data, expected_final_timing_data):
-        app.util.fs.write_file(json.dumps(existing_timing_data), self._timing_file_path)
+        fs.write_file(json.dumps(existing_timing_data), self._timing_file_path)
         build_artifact = BuildArtifact('/some/dir/doesnt/matter')
         build_artifact._update_timing_file(self._timing_file_path, new_timing_data)
 
@@ -33,3 +43,19 @@ class TestBuildArtifact(BaseIntegrationTestCase):
             updated_timing_data = json.load(timing_file)
 
         self.assertDictEqual(updated_timing_data, expected_final_timing_data)
+
+    def test_get_failed_subjob_and_atom_ids_returns_correct_ids(self):
+        """
+        Build artifact directory:
+            artifact_1_0/clusterrunner_exit_code -> 0
+            artifact_1_1/clusterrunner_exit_code -> 1
+            artifact_2_0/clusterrunner_exit_code -> 0
+            artifact_2_1/clusterrunner_exit_code -> 1
+
+        Expected to return: [(1,1), (2,1)]
+        """
+        build_artifact = BuildArtifact(self._artifact_directory_path)
+        failed_subjob_and_atoms = build_artifact.get_failed_subjob_and_atom_ids()
+        self.assertIn((1, 1), failed_subjob_and_atoms)
+        self.assertIn((2, 1), failed_subjob_and_atoms)
+        self.assertEquals(2, len(failed_subjob_and_atoms))

--- a/test/unit/master/test_build_artifact.py
+++ b/test/unit/master/test_build_artifact.py
@@ -32,3 +32,23 @@ class TestBuildArtifact(BaseUnitTestCase):
     def test_artifact_directory_raises_value_error_if_subjob_id_or_atom_id_specified(self, subjob_id, atom_id):
         with self.assertRaises(ValueError):
             BuildArtifact._artifact_directory(1, subjob_id, atom_id)
+
+    @genty_dataset(
+        relative_path=('artifact_0_1', 0, 1),
+        absolute_path=('/path/to/build/1/artifact_0_1', 0, 1),
+    )
+    def test_subjob_and_atom_ids_parses_for_properly_formatted_directory(self, artifact_directory, expected_subjob_id,
+                                                                         expected_atom_id):
+        subjob_id, atom_id = BuildArtifact._subjob_and_atom_ids(artifact_directory)
+        self.assertEquals(subjob_id, expected_subjob_id)
+        self.assertEquals(atom_id, expected_atom_id)
+
+    @genty_dataset(
+        'artifact_0',
+        '/full/path/artifact_0',
+        'wrong_0_1',
+    )
+    def test_subjob_and_atom_ids_raises_value_error_with_incorrect_format(self, incorrect_artifact_directory):
+        with self.assertRaises(ValueError):
+            BuildArtifact._subjob_and_atom_ids(incorrect_artifact_directory)
+


### PR DESCRIPTION
to return an API representation of the whole atom.