### PR TITLE
Build refactor - Create BuildScheduler class

### DIFF
--- a/app/master/build_scheduler.py
+++ b/app/master/build_scheduler.py
@@ -1,0 +1,122 @@
+from queue import Empty
+from threading import Lock
+
+from app.master.slave import SlaveMarkedForShutdownError
+from app.util import analytics
+from app.util.log import get_logger
+
+# pylint: disable=protected-access
+# Disable protected-access for whole file; will be fixing this (by
+# moving Build's subjob queues into this class) in a separate change.
+
+
+class BuildScheduler(object):
+    """
+    This class handles the logic of taking a Build and distributing its subjobs to
+    slaves. There is a one-to-one relationship between instances of this class and
+    instances of Build.
+
+    The data flow between this class and Build is unidirectional; the build instance
+    itself shouldn't know anything about its scheduler or slaves or where subjobs
+    are executing. All that goes here.
+
+    Ususally this class is instantiated and managed by a BuildSchedulerPool.
+    """
+    def __init__(self, build):
+        """
+        :type build: Build
+        """
+        self._logger = get_logger(__name__)
+        self._build = build
+
+        job_config = build.project_type.job_config()
+        self._max_executors = job_config.max_executors
+        self._max_executors_per_slave = job_config.max_executors_per_slave
+
+        self._slaves_allocated = []
+        self._num_executors_allocated = 0
+        self._num_executors_in_use = 0
+        self._subjob_assignment_lock = Lock()  # prevents subjobs from being skipped
+
+    @property
+    def build_id(self):
+        """ :rtype: int """
+        return self._build.build_id()
+
+    def needs_more_slaves(self):
+        """
+        Determine whether or not this build should have more slaves allocated to it.
+
+        :rtype: bool
+        """
+        return self._num_executors_allocated < self._max_executors and not self._build._unstarted_subjobs.empty()
+
+    def allocate_slave(self, slave):
+        """
+        Allocate a slave to this build. This tells the slave to execute setup commands for this build.
+
+        :type slave: Slave
+        """
+        if not self._slaves_allocated:
+            # If this is the first slave to be allocated, update the build state.
+            self._build.mark_started()
+
+        self._slaves_allocated.append(slave)
+        slave.setup(self._build, executor_start_index=self._num_executors_allocated)
+        self._num_executors_allocated += min(slave.num_executors, self._max_executors_per_slave)
+        analytics.record_event(analytics.BUILD_SETUP_START, build_id=self._build.build_id(), slave_id=slave.id)
+
+    def begin_subjob_executions_on_slave(self, slave):
+        """
+        Begin subjob executions on a slave. This should be called once after the specified slave has already run
+        build_setup commands for this build.
+
+        :type slave: Slave
+        """
+        analytics.record_event(analytics.BUILD_SETUP_FINISH, build_id=self._build.build_id(), slave_id=slave.id)
+        for slave_executor_count in range(slave.num_executors):
+            if (self._num_executors_in_use >= self._max_executors
+                    or slave_executor_count >= self._max_executors_per_slave):
+                break
+            slave.claim_executor()
+            self._num_executors_in_use += 1
+            self.execute_next_subjob_or_free_executor(slave)
+
+    def execute_next_subjob_or_free_executor(self, slave):
+        """
+        Grabs an unstarted subjob off the queue and sends it to the specified slave to be executed. If the unstarted
+        subjob queue is empty, we teardown the slave to free it up for other builds.
+
+        :type slave: Slave
+        """
+        try:
+            # This lock prevents the scenario where a subjob is pulled from the queue but cannot be assigned to this
+            # slave because it is shutdown, so we put it back on the queue but in the meantime another slave enters
+            # this method, finds the subjob queue empty, and is torn down.  If that was the last 'living' slave, the
+            # build would be stuck.
+            with self._subjob_assignment_lock:
+                subjob = self._build._unstarted_subjobs.get(block=False)
+                self._logger.debug('Sending subjob {} (build {}) to slave {}.',
+                                   subjob.subjob_id(), subjob.build_id(), slave.url)
+                try:
+                    slave.start_subjob(subjob)
+                    subjob.mark_in_progress(slave)
+
+                except SlaveMarkedForShutdownError:
+                    self._build._unstarted_subjobs.put(subjob)  # todo: This changes subjob execution order. (Issue #226)
+                    # An executor is currently allocated for this subjob in begin_subjob_executions_on_slave.
+                    # Since the slave has been marked for shutdown, we need to free the executor.
+                    self._free_slave_executor(slave)
+
+        except Empty:
+            self._free_slave_executor(slave)
+
+    def _free_slave_executor(self, slave):
+        num_executors_in_use = slave.free_executor()
+        if num_executors_in_use == 0:
+            try:
+                self._slaves_allocated.remove(slave)
+            except ValueError:
+                pass  # We have already deallocated this slave, no need to teardown
+            else:
+                slave.teardown()

--- a/app/master/build_scheduler_pool.py
+++ b/app/master/build_scheduler_pool.py
@@ -1,0 +1,28 @@
+from threading import Lock
+
+from app.master.build_scheduler import BuildScheduler
+
+
+class BuildSchedulerPool(object):
+    """
+    A BuildSchedulerPool creates and manages a group of BuildScheduler instances.
+    Since there is a one-to-one relationship between Build and BuildScheduler, this
+    class exists to make it easier to create and manage scheduler instances.
+    """
+    def __init__(self):
+        self._schedulers_by_build_id = {}
+        self._scheduler_creation_lock = Lock()
+
+    def get(self, build):
+        """
+        :type build: Build
+        :rtype: BuildScheduler
+        """
+        with self._scheduler_creation_lock:
+            scheduler = self._schedulers_by_build_id.get(build.build_id())
+            if scheduler is None:
+                # WIP: clean up old schedulers (search through list and remove any with finished builds)
+                scheduler = BuildScheduler(build)
+                self._schedulers_by_build_id[build.build_id()] = scheduler
+
+        return scheduler

--- a/app/master/slave.py
+++ b/app/master/slave.py
@@ -54,13 +54,15 @@ class Slave(object):
             self.kill()
             raise SlaveMarkedForShutdownError
 
-    def setup(self, build):
+    def setup(self, build, executor_start_index):
         """
         Execute a setup command on the slave for the specified build. The setup process executes asynchronously on the
         slave and the slave will alert the master when setup is complete and it is ready to start working on subjobs.
 
         :param build: The build to set up this slave to work on
         :type build: Build
+        :param executor_start_index: The index the slave should number its executors from for this build
+        :type executor_start_index: int
         """
         slave_project_type_params = build.build_request.build_parameters().copy()
         slave_project_type_params.update(build.project_type.slave_param_overrides())
@@ -68,7 +70,7 @@ class Slave(object):
         setup_url = self._slave_api.url('build', build.build_id(), 'setup')
         post_data = {
             'project_type_params': slave_project_type_params,
-            'build_executor_start_index': build.num_executors_allocated,
+            'build_executor_start_index': executor_start_index,
         }
 
         self.current_build_id = build.build_id()

--- a/test/unit/master/test_build_request_handler.py
+++ b/test/unit/master/test_build_request_handler.py
@@ -1,5 +1,6 @@
 from genty import genty, genty_dataset
 from unittest.mock import Mock
+from app.master.build_scheduler_pool import BuildSchedulerPool
 
 from app.project_type.project_type import ProjectType
 from app.master.atom import Atom
@@ -23,18 +24,19 @@ class TestBuildRequestHandler(BaseUnitTestCase):
         :type atomizer_called: bool
         """
         self.patch('os.path.isfile').return_value = False
-        mock_project = Mock(spec=ProjectType)
+        mock_project = Mock(spec_set=ProjectType())
         mock_project.atoms_override = atoms_override
         mock_project.timing_file_path.return_value = '/some/path/doesnt/matter'
         mock_project.project_directory = '/some/project/directory'
-        mock_atomizer = Mock(spec=Atomizer)
+        mock_atomizer = Mock(spec_set=Atomizer)
         mock_atomizer.atomize_in_project.return_value = atomizer_output
         mock_job_config = Mock(spec=JobConfig)
         mock_job_config.name = 'some_config'
         mock_job_config.max_executors = 1
         mock_job_config.atomizer = mock_atomizer
-        build_request_handler = BuildRequestHandler()
+        mock_scheduler_pool = Mock(spec_set=BuildSchedulerPool)
 
+        build_request_handler = BuildRequestHandler(mock_scheduler_pool)
         build_request_handler._compute_subjobs_for_build(build_id=1, job_config=mock_job_config,
                                                          project_type=mock_project)
 

--- a/test/unit/master/test_slave.py
+++ b/test/unit/master/test_slave.py
@@ -50,10 +50,10 @@ class TestSlave(BaseUnitTestCase):
             'url': 'ssh://new-url-for-clusterrunner-master',
             'extra': 'something_extra',
         }))
-        mock_build = MagicMock(spec=Build, num_executors_allocated=777, build_request=build_request,
+        mock_build = MagicMock(spec=Build, build_request=build_request,
                                build_id=Mock(return_value=888), project_type=mock_git)
 
-        slave.setup(mock_build)
+        slave.setup(mock_build, executor_start_index=777)
 
         slave._network.post_with_digest.assert_called_with(
             'http://{}/v1/build/888/setup'.format(self._FAKE_SLAVE_URL),
@@ -78,7 +78,7 @@ class TestSlave(BaseUnitTestCase):
                              'slave.current_build_id should be set before the master tells the slave to do setup.')
 
         slave._network.post_with_digest = Mock(side_effect=assert_slave_build_id_is_already_set)
-        slave.setup(mock_build)
+        slave.setup(mock_build, executor_start_index=0)
 
         self.assertEqual(slave._network.post_with_digest.call_count, 1,
                          'The behavior that this test is checking depends on slave setup being triggered via '

--- a/test/unit/master/test_slave_allocator.py
+++ b/test/unit/master/test_slave_allocator.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock
 
 from app.master.build import Build
+from app.master.build_request_handler import BuildRequestHandler
 from app.master.slave import Slave
 from app.master.slave_allocator import SlaveAllocator
 from test.framework.base_unit_test_case import BaseUnitTestCase
@@ -28,7 +29,7 @@ class TestSlaveAllocator(BaseUnitTestCase):
                           allocate_slave=Mock(side_effect=AbortLoopForTesting))
         mock_slave = Mock(spec=Slave, url='', is_alive=Mock(return_value=True), is_shutdown=Mock(return_value=False))
         slave_allocator = self._create_slave_allocator()
-        slave_allocator._build_request_handler.next_prepared_build = Mock(return_value=mock_build)
+        slave_allocator._build_request_handler.next_prepared_build_scheduler = Mock(return_value=mock_build)
         slave_allocator._idle_slaves.get = Mock(return_value=mock_slave)
 
         self.assertRaises(AbortLoopForTesting, slave_allocator._slave_allocation_loop)
@@ -37,7 +38,7 @@ class TestSlaveAllocator(BaseUnitTestCase):
         mock_build = Mock(spec=Build, needs_more_slaves=Mock(side_effect=[True, False]))
         mock_slave = Mock(spec=Slave, url='', is_alive=Mock(return_value=True), is_shutdown=Mock(return_value=False))
         slave_allocator = self._create_slave_allocator()
-        slave_allocator._build_request_handler.next_prepared_build = Mock(return_value=mock_build)
+        slave_allocator._build_request_handler.next_prepared_build_scheduler = Mock(return_value=mock_build)
         slave_allocator._idle_slaves.get = Mock(return_value=mock_slave)
         slave_allocator.add_idle_slave = Mock(side_effect=AbortLoopForTesting)
 
@@ -70,7 +71,7 @@ class TestSlaveAllocator(BaseUnitTestCase):
         :param kwargs: Any constructor parameters for the slave; if none are specified, test defaults will be used.
         :rtype: SlaveAllocator
         """
-        kwargs.setdefault('build_request_handler', Mock())
+        kwargs.setdefault('build_request_handler', Mock(spec_set=BuildRequestHandler))
         return SlaveAllocator(**kwargs)
 
 class AbortLoopForTesting(Exception):

--- a/test/unit/test_test.py
+++ b/test/unit/test_test.py
@@ -13,8 +13,10 @@ class TestTest(BaseUnitTestCase):
         repo_test_dir_path = dirname(dirname(__file__))
         self.assertEqual(basename(repo_test_dir_path), 'test', 'repo_test_dir_path should be the path of the top-level '
                                                                '"test" directory in the ClusterRunner repo.')
+
+        exempt_dirs = ['__pycache__', '.hypothesis']  # skip special directories
         for dir_path, _, files in os.walk(repo_test_dir_path):
-            if '__pycache__' in dir_path:  # skip special directories
+            if any(exempt_dir in dir_path for exempt_dir in exempt_dirs):
                 continue
 
             self.assertIn(


### PR DESCRIPTION
This is one of a few changes I have queued up to refactor our Build
class to not be terrible.

- Break out anything in the `Build` class related to slave interaction
  into a new `BuildScheduler` class.

  A `BuildScheduler` has a one-to-one relationship with a `Build`.
  Every build gets a scheduler. The build does not know anything about
  the scheduler, and the scheduler only interacts with the build via
  its public interface.

- Create a `BuildSchedulerPool` class to help with managing
  `BuildScheduler` instances. This prevents `ClusterMaster` from
  needing to keep yet another id-to-instance dict.

  The `BuildSchedulerPool` will also eventually take care of cleaning
  up old scheduler instances.