### PR TITLE
added subjob id to atom

### DIFF
--- a/app/master/atom.py
+++ b/app/master/atom.py
@@ -15,7 +15,8 @@ class Atom(object):
             actual_time=None,
             exit_code=None,
             state=None,
-            atom_id=None
+            atom_id=None,
+            subjob_id=None
     ):
         """
         :type command_string: str
@@ -24,12 +25,14 @@ class Atom(object):
         :type exit_code: int | None
         :type state: `:class:AtomState` | None
         :type atom_id: int | None
+        :type subjob_id: int | None
         """
         self.command_string = command_string
         self.expected_time = expected_time
         self.actual_time = actual_time
         self.exit_code = exit_code
         self.state = state
+        self.subjob_id = subjob_id
         self.id = atom_id
 
     def api_representation(self):
@@ -40,4 +43,5 @@ class Atom(object):
             'exit_code': self.exit_code,
             'state': self.state,
             'id': self.id,
+            'subjob_id': self.subjob_id,
         }

--- a/app/master/subjob.py
+++ b/app/master/subjob.py
@@ -27,9 +27,21 @@ class Subjob(object):
         self.project_type = project_type
         self.job_config = job_config
         self._atoms = atoms
+        self._set_atoms_subjob_id(atoms, subjob_id)
         self._set_atom_state(AtomState.NOT_STARTED)
         self.timings = {}  # a dict, atom_ids are the keys and seconds are the values
         self.slave = None  # The slave that had been assigned this subjob. Is None if not started.
+
+    def _set_atoms_subjob_id(self, atoms, subjob_id):
+        """
+        Set the subjob_id on each atom
+        :param atoms: an array of atoms to set the subjob_id on
+        :type atoms: list[app.master.atom.Atom]
+        :param subjob_id: the subjob_id to set on the atoms
+        :type subjob_id: int
+        """
+        for atom in atoms:
+            atom.subjob_id = subjob_id
 
     def _set_atom_state(self, state):
         """

--- a/test/unit/master/test_subjob.py
+++ b/test/unit/master/test_subjob.py
@@ -36,6 +36,12 @@ class TestSubjob(BaseUnitTestCase):
             ],
         )
 
+    def test_set_atoms_subjob_id(self):
+        atoms = [Mock(), Mock()]
+        self._subjob._set_atoms_subjob_id(atoms, 4)
+        for atom in atoms:
+            self.assertEqual(atom.subjob_id, 4)
+
     def test_api_representation_matches_expected(self):
         actual_api_repr = self._subjob.api_representation()
 
@@ -51,6 +57,7 @@ class TestSubjob(BaseUnitTestCase):
                     'actual_time': 56.7,
                     'exit_code': 1,
                     'state': 'NOT_STARTED',
+                    'subjob_id': 34
                 },
                 {
                     'id': 1,
@@ -59,6 +66,7 @@ class TestSubjob(BaseUnitTestCase):
                     'actual_time': 24.6,
                     'exit_code': 0,
                     'state': 'NOT_STARTED',
+                    'subjob_id': 34
                 },
             ]
         }


### PR DESCRIPTION
added subjob id field to atom's api representation. This will make the is-it-your-fault-service cleaner