### PR TITLE
fixed error in the atom api handler

### DIFF
--- a/app/web_framework/cluster_master_application.py
+++ b/app/web_framework/cluster_master_application.py
@@ -173,7 +173,7 @@ class _AtomHandler(_ClusterMasterBaseAPIHandler):
     def get(self, build_id, subjob_id, atom_id):
         build = self._cluster_master.get_build(int(build_id))
         subjob = build.subjob(int(subjob_id))
-        atoms = subjob.atoms()
+        atoms = subjob.atoms
         response = {
             'atom': atoms[int(atom_id)].api_representation(),
         }


### PR DESCRIPTION
I found an error in the atom api. If you visit 
http://pod4101-automation1024.pod.box.net:43000/v1/build/100/subjob/0/atom
or any similar url, you get    error: "'list' object is not callable"
In the atom handler we were trying to do subjob.atoms() to get the atoms for a subjob, but subjob.atoms is a list of atoms, not a function that returns atoms