### PR TITLE
Move job validation and unpacking logic into JobConfig class.

### DIFF
--- a/app/master/cluster_runner_config.py
+++ b/app/master/cluster_runner_config.py
@@ -1,23 +1,13 @@
-import sys
 import yaml
 
-from app.master.atomizer import Atomizer
 from app.master.job_config import JobConfig
 from app.util import log
 
 
-# clusterrunner.yaml config section names
-SETUP_BUILD = 'setup_build'
-TEARDOWN_BUILD = 'teardown_build'
-COMMANDS = 'commands'
-ATOMIZERS = 'atomizers'
-MAX_EXECUTORS = 'max_executors'
-MAX_EXECUTORS_PER_SLAVE = 'max_executors_per_slave'
-
-
 class ClusterRunnerConfig(object):
-    DEFAULT_MAX_EXECUTORS = sys.maxsize
-
+    """
+    This class represents all of the ClusterRunner job definitions that live inside a single clusterrunner.yaml file.
+    """
     def __init__(self, raw_yaml_contents):
         """
         :param raw_yaml_contents: Raw string contents of project clusterrunner.yaml file
@@ -62,121 +52,26 @@ class ClusterRunnerConfig(object):
         return list(self._job_configs.keys())
 
     def _parse_raw_config(self):
-        config = yaml.safe_load(self._raw_yaml_contents)
-        self._validate(config)
-        self._set_config(config)
-
-    def _validate(self, config):
         """
         Validate the parsed yaml structure. This method raises on validation errors.
+
+        If validation is successful, add the job configs to this class instance.
+
         :param config: The parsed yaml data
         :type config: dict
         """
+        config = yaml.safe_load(self._raw_yaml_contents)
+
         if not isinstance(config, dict):
             raise ConfigParseError('The yaml config file could not be parsed to a dictionary')
 
-        required_fields = {COMMANDS, ATOMIZERS}
-        allowed_fields_expected_types = {
-            SETUP_BUILD: [(list, str)],  # (list, str) means this field should be a list of strings
-            TEARDOWN_BUILD: [(list, str)],
-            COMMANDS: [(list, str)],
-            ATOMIZERS: [(list, dict)],  # (list, dict) means this field should be a list of dicts
-            MAX_EXECUTORS: [int],
-            MAX_EXECUTORS_PER_SLAVE: [int],
-        }
+        self._job_configs = {}
 
         for job_name, job_config_sections in config.items():
-            if not isinstance(job_config_sections, dict):
-                raise ConfigValidationError('Invalid definition in project yaml file for job "{}".'.format(job_name))
-
-            missing_required_fields = required_fields - job_config_sections.keys()
-            if missing_required_fields:
-                raise ConfigValidationError('Definition for job "{}" in project yaml is missing required config '
-                                            'sections: {}.'.format(job_name, missing_required_fields))
-
-            for config_section_name, config_section_value in job_config_sections.items():
-                if config_section_name not in allowed_fields_expected_types:
-                    raise ConfigValidationError('Definition for job "{}" in project yaml contains an invalid config '
-                                                'section "{}".'.format(job_name, config_section_name))
-
-                expected_section_types = allowed_fields_expected_types[config_section_name]
-                actual_section_type = type(config_section_value)
-                if actual_section_type is list:
-                    # also check the type of the list items (assuming all list items have the same type as the first)
-                    actual_section_type = (list, type(config_section_value[0]))
-
-                if actual_section_type not in expected_section_types:
-                    raise ConfigValidationError(
-                        'Definition for job "{}" in project yaml contains an invalid value for config section "{}". '
-                        'Parser expected one of {} but found {}.'
-                        .format(job_name, config_section_name, expected_section_types, actual_section_type))
-
-    def _set_config(self, config):
-        """
-        Translate the parsed and validated config data into JobConfig objects, and save the results to an attribute
-        on this instance.
-        :param config: Config values for one or more jobs, with job names as the keys
-        :type config: dict [str, dict]
-        """
-        self._job_configs = {job_name: self._construct_job_config(job_name, job_values)
-                             for job_name, job_values in config.items()}
+            self._job_configs[job_name] = JobConfig.construct_from_dict(job_name, job_config_sections)
 
         if len(self._job_configs) == 0:
             raise ConfigParseError('No jobs found in the config.')
-
-    def _construct_job_config(self, job_name, job_values):
-        """
-        Produce a JobConfig object given a dictionary of values parsed from a yaml config file.
-        :param job_name: The name of the job
-        :type job_name: str
-        :param job_values: The dict of config sections for this job as parsed from the yaml file
-        :type job_values: dict
-        :return: A JobConfig object wrapping the normalized data for the specified job
-        :rtype: JobConfig
-        """
-        # Each value should be transformed from a list of commands to a single command string.
-        setup_build = self._shell_command_list_to_single_command(job_values.get(SETUP_BUILD))
-        teardown_build = self._shell_command_list_to_single_command(job_values.get(TEARDOWN_BUILD))
-        command = self._shell_command_list_to_single_command(job_values[COMMANDS])
-
-        atomizer = Atomizer(job_values[ATOMIZERS])
-        max_executors = job_values.get(MAX_EXECUTORS, self.DEFAULT_MAX_EXECUTORS)
-        max_executors_per_slave = job_values.get(MAX_EXECUTORS_PER_SLAVE, self.DEFAULT_MAX_EXECUTORS)
-
-        return JobConfig(job_name, setup_build, teardown_build, command, atomizer, max_executors,
-                         max_executors_per_slave)
-
-    def _shell_command_list_to_single_command(self, commands):
-        """
-        Combines a list of commands into a single command string
-        :param commands: a list of commands, optionally ending with semicolons
-        :type commands: list[str|None]
-        :return: returns the concatenated shell command on success, or None if there was an error
-        :rtype: string|None
-        """
-        if not isinstance(commands, list):
-            return None
-
-        # We should join the commands with double ampersands UNLESS the command already ends with a single ampersand.
-        # A semicolon (or a double ampersand) is invalid syntax after a single ampersand.
-        sanitized_commands = []
-        for command in commands:
-            if command is None:
-                # skip `None` command in the commands list
-                continue
-            stripped_command = command.strip().rstrip(';')
-            # If the command ends with an ampersand (single or double) we can leave the command alone (empty postfix)
-            postfix = ' ' if stripped_command.strip().endswith('&') else ' && '
-            sanitized_commands.append(stripped_command + postfix)
-
-        # '&&' must not be appended to the command for the last shell command. For the sake of homogeneity of the
-        # loop above, we just strip out the '&&' here.
-        joined_commands = ''.join(sanitized_commands).strip()
-
-        if joined_commands.endswith('&&'):
-            joined_commands = joined_commands.rstrip('&').strip()
-
-        return joined_commands
 
 
 class ConfigParseError(Exception):
@@ -194,10 +89,4 @@ class JobNotFoundError(Exception):
 class JobNotSpecifiedError(Exception):
     """
     Multiple jobs were found in the config but none were specified
-    """
-
-
-class ConfigValidationError(Exception):
-    """
-    The cluster runner config was invalid
     """

--- a/app/master/job_config.py
+++ b/app/master/job_config.py
@@ -1,12 +1,29 @@
+import sys
+
+from app.master.atomizer import Atomizer
+
+
+# config section names/keys
+SETUP_BUILD = 'setup_build'
+TEARDOWN_BUILD = 'teardown_build'
+COMMANDS = 'commands'
+ATOMIZERS = 'atomizers'
+MAX_EXECUTORS = 'max_executors'
+MAX_EXECUTORS_PER_SLAVE = 'max_executors_per_slave'
 
 
 class JobConfig(object):
+    """
+    This class represents a single ClusterRunner job definition.
+    """
+    DEFAULT_MAX_EXECUTORS = sys.maxsize
+
     def __init__(self, name, setup_build, teardown_build, command, atomizer, max_executors, max_executors_per_slave):
         """
         :type name: str
-        :type setup_build: str | None
-        :type teardown_build: str | None
-        :type command: str
+        :type setup_build: list[str] | None
+        :type teardown_build: list[str] | None
+        :type command: list[str]
         :type atomizer: Atomizer
         :type max_executors: int | None
         :type max_executors_per_slave: int | None
@@ -18,3 +35,119 @@ class JobConfig(object):
         self.atomizer = atomizer
         self.max_executors = max_executors
         self.max_executors_per_slave = max_executors_per_slave
+
+    @classmethod
+    def construct_from_dict(cls, name, config_dict):
+        """
+        First validate the config_dict contents. Raises an exception if validation fails.
+        Upon validation success, return an instance of JobConfig.
+
+        :param name: The name of this job configuration.
+        :type name: str
+        :param config_dict: a dictionary with the keys being config sections (e.g.: setup_build, commands, etc)
+        :type config_dict: dict
+        :return: JobConfig
+        """
+        cls._validate(name, config_dict)
+        return cls._unpack(name, config_dict)
+
+    @classmethod
+    def _validate(cls, name, config_dict):
+        """
+        Raises a ConfigValidationError in case of an invalid configuration.
+
+        :type name: str
+        :type config_dict: dict
+        :rtype: None
+        """
+        required_fields = {COMMANDS, ATOMIZERS}
+        allowed_fields_expected_types = {
+            SETUP_BUILD: [(list, str)],  # (list, str) means this field should be a list of strings
+            TEARDOWN_BUILD: [(list, str)],
+            COMMANDS: [(list, str)],
+            ATOMIZERS: [(list, dict)],  # (list, dict) means this field should be a list of dicts
+            MAX_EXECUTORS: [int],
+            MAX_EXECUTORS_PER_SLAVE: [int],
+        }
+
+        if not isinstance(config_dict, dict):
+            raise ConfigValidationError('Passed in configuration is not a dictionary for job: "{}".'.format(name))
+
+        missing_required_fields = required_fields - config_dict.keys()
+        if missing_required_fields:
+            raise ConfigValidationError('Definition for job "{}" is missing required config sections: {}'
+                                        .format(name, missing_required_fields))
+
+        for config_section_name, config_section_value in config_dict.items():
+            if config_section_name not in allowed_fields_expected_types:
+                raise ConfigValidationError('Definition for job "{}" contains an invalid config section "{}".'
+                                            .format(name, config_section_name))
+
+            expected_section_types = allowed_fields_expected_types[config_section_name]
+            actual_section_type = type(config_section_value)
+            if actual_section_type is list:
+                # also check the type of the list items (assuming all list items have the same type as the first)
+                actual_section_type = (list, type(config_section_value[0]))
+
+            if actual_section_type not in expected_section_types:
+                raise ConfigValidationError(
+                    'Definition for job "{}" contains an invalid value for config section "{}". '
+                    'Parser expected one of {} but found {}.'
+                    .format(name, config_section_name, expected_section_types, actual_section_type))
+
+    @classmethod
+    def _unpack(cls, name, config_dict):
+        """
+        Set class attributes from config dictionary.
+
+        :type name: str
+        :type config_dict: dict
+        :rtype: JobConfig
+        """
+        setup_build = cls._shell_command_list_to_single_command(config_dict.get(SETUP_BUILD))
+        teardown_build = cls._shell_command_list_to_single_command(config_dict.get(TEARDOWN_BUILD))
+        command = cls._shell_command_list_to_single_command(config_dict[COMMANDS])
+        atomizer = Atomizer(config_dict[ATOMIZERS])
+        max_executors = config_dict.get(MAX_EXECUTORS, cls.DEFAULT_MAX_EXECUTORS)
+        max_executors_per_slave = config_dict.get(MAX_EXECUTORS_PER_SLAVE, cls.DEFAULT_MAX_EXECUTORS)
+        return cls(name, setup_build, teardown_build, command, atomizer, max_executors, max_executors_per_slave)
+
+    @classmethod
+    def _shell_command_list_to_single_command(cls, commands):
+        """
+        Combines a list of commands into a single command string
+
+        :param commands: a list of commands, optionally ending with semicolons
+        :type commands: list[str|None]
+        :return: returns the concatenated shell command on success, or None if there was an error
+        :rtype: string|None
+        """
+        if not isinstance(commands, list):
+            return None
+
+        # We should join the commands with double ampersands UNLESS the command already ends with a single ampersand.
+        # A semicolon (or a double ampersand) is invalid syntax after a single ampersand.
+        sanitized_commands = []
+        for command in commands:
+            if command is None:
+                # skip `None` command in the commands list
+                continue
+            stripped_command = command.strip().rstrip(';')
+            # If the command ends with an ampersand (single or double) we can leave the command alone (empty postfix)
+            postfix = ' ' if stripped_command.strip().endswith('&') else ' && '
+            sanitized_commands.append(stripped_command + postfix)
+
+        # '&&' must not be appended to the command for the last shell command. For the sake of homogeneity of the
+        # loop above, we just strip out the '&&' here.
+        joined_commands = ''.join(sanitized_commands).strip()
+
+        if joined_commands.endswith('&&'):
+            joined_commands = joined_commands.rstrip('&').strip()
+
+        return joined_commands
+
+
+class ConfigValidationError(Exception):
+    """
+    The cluster runner config was invalid
+    """

--- a/test/unit/master/test_cluster_runner_config.py
+++ b/test/unit/master/test_cluster_runner_config.py
@@ -2,7 +2,8 @@ from genty import genty, genty_dataset
 import sys
 
 from app.master.atomizer import Atomizer
-from app.master.cluster_runner_config import ClusterRunnerConfig, ConfigParseError, ConfigValidationError
+from app.master.job_config import ConfigValidationError
+from app.master.cluster_runner_config import ClusterRunnerConfig, ConfigParseError
 from test.framework.base_unit_test_case import BaseUnitTestCase
 
 

--- a/test/unit/master/test_job_config.py
+++ b/test/unit/master/test_job_config.py
@@ -1,0 +1,44 @@
+from genty import genty, genty_dataset
+
+from app.master.job_config import JobConfig, ConfigValidationError
+from test.framework.base_unit_test_case import BaseUnitTestCase
+
+
+@genty
+class TestJobConfig(BaseUnitTestCase):
+
+    @genty_dataset(
+        {'atomizers': [{'TESTPATH': 'atomizer command'}]},
+        {'commands': ['shell command 1', 'shell command 2;']}
+    )
+    def test_construct_from_dict_raise_error_without_requried_fields(self, config_dict):
+        with self.assertRaises(ConfigValidationError):
+            JobConfig.construct_from_dict('some_job_name', config_dict)
+
+    def test_construct_from_dict_for_valid_conf_with_only_required_fields(self):
+        config_dict = {
+            'commands': ['shell command 1', 'shell command 2;'],
+            'atomizers': [{'TESTPATH': 'atomizer command'}],
+        }
+        job_config = JobConfig.construct_from_dict('some_job_name', config_dict)
+
+        self.assertEquals(job_config.command, 'shell command 1 && shell command 2')
+        self.assertEquals(job_config.name, 'some_job_name')
+
+    def test_construct_from_dict_for_valid_conf_with_all_fields(self):
+        config_dict = {
+            'commands': ['shell command 1', 'shell command 2;'],
+            'atomizers': [{'TESTPATH': 'atomizer command'}],
+            'setup_build': ['setup command 1;', 'setup command 2;'],
+            'teardown_build': ['teardown command 1;', 'teardown command 2;'],
+            'max_executors': 100,
+            'max_executors_per_slave': 2,
+        }
+        job_config = JobConfig.construct_from_dict('some_job_name', config_dict)
+
+        self.assertEquals(job_config.command, 'shell command 1 && shell command 2')
+        self.assertEquals(job_config.name, 'some_job_name')
+        self.assertEquals(job_config.setup_build, 'setup command 1 && setup command 2')
+        self.assertEquals(job_config.teardown_build, 'teardown command 1 && teardown command 2')
+        self.assertEquals(job_config.max_executors, 100)
+        self.assertEquals(job_config.max_executors_per_slave, 2)


### PR DESCRIPTION
Currently the instantiation of the JobConfig object is tied to the ClusterRunnerConfig class. This change moves that construction logic into the JobConfig's class method, to form a sort of factory method.

This change is necessary for an upcoming change where I would like to construct JobConfig objects directly, without having to go through the ClusterRunnerConfig class. The ClusterRunnerConfig class is tied to the yaml format, as it accepts the raw yaml contents of a whole clusterrunner.yaml file as its constructor argument. 

This is problematic for the feature we would like to implement, where you can post the fields of the config via the POST request in a JSON body, not in yaml format.

