### PR TITLE
Accept formatted JSON in the build request to specify the job config.

### DIFF
--- a/app/master/build_request.py
+++ b/app/master/build_request.py
@@ -19,9 +19,18 @@ class BuildRequest(object):
         "type": "git",
         "url": "ssh://github.com/drobertduke/some-project",
         "branch": "master",
-        "job_name": "clusterrunner_configured_job",
+        [OPTIONAL] "job_name": "clusterrunner_configured_job",
+            - This field is optional if the "config" section is specified
         [OPTIONAL] "atoms_override": ['export VAR="overridden_atom_value_1";', ...],
         [OPTIONAL] "hash": "123456789123456789123456789"
+        [OPTIONAL] "config": {
+            "commands" : [...],
+            "atomizers" : {...},
+            "setup_build": [...],
+            "teardown_build": [...],
+            "max_executors": ...,
+            "max_executors_per_slave": ...
+        }
     }
     """
     def __init__(self, build_parameters):

--- a/test/functional/master/test_endpoints.py
+++ b/test/functional/master/test_endpoints.py
@@ -1,4 +1,5 @@
 import os
+import yaml
 
 from test.framework.functional.base_functional_test_case import BaseFunctionalTestCase
 from test.functional.job_configs import BASIC_JOB
@@ -8,10 +9,9 @@ class TestMasterEndpoints(BaseFunctionalTestCase):
 
     def _start_master_only_and_post_a_new_job(self):
         master = self.cluster.start_master()
-
         build_resp = master.post_new_build({
             'type': 'directory',
-            'config': BASIC_JOB.config[os.name],
+            'config': yaml.safe_load(BASIC_JOB.config[os.name])['BasicJob'],
             'project_directory': '/tmp',
             })
         build_id = build_resp['build_id']

--- a/test/functional/master/test_shutdown.py
+++ b/test/functional/master/test_shutdown.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+import yaml
 
 from test.framework.functional.base_functional_test_case import BaseFunctionalTestCase
 from test.functional.job_configs import JOB_WITH_SETUP_AND_TEARDOWN
@@ -46,7 +47,7 @@ class TestShutdown(BaseFunctionalTestCase):
         project_dir = tempfile.TemporaryDirectory()
         build_resp = master.post_new_build({
             'type': 'directory',
-            'config': JOB_WITH_SETUP_AND_TEARDOWN.config[os.name],
+            'config': yaml.safe_load(JOB_WITH_SETUP_AND_TEARDOWN.config[os.name])['JobWithSetupAndTeardown'],
             'project_directory': project_dir.name,
             })
         build_id = build_resp['build_id']

--- a/test/functional/test_cluster_basic.py
+++ b/test/functional/test_cluster_basic.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 from unittest import skip
+import yaml
 
 from genty import genty, genty_dataset
 
@@ -13,18 +14,18 @@ from test.functional.job_configs import BASIC_FAILING_JOB, BASIC_JOB, JOB_WITH_S
 class TestClusterBasic(BaseFunctionalTestCase):
 
     @genty_dataset(
-        basic_job=(BASIC_JOB,),
-        basic_failing_job=(BASIC_FAILING_JOB,),
-        job_with_setup_and_teardown=(JOB_WITH_SETUP_AND_TEARDOWN,),
+        basic_job=(BASIC_JOB, 'BasicJob'),
+        basic_failing_job=(BASIC_FAILING_JOB, 'BasicFailingJob'),
+        job_with_setup_and_teardown=(JOB_WITH_SETUP_AND_TEARDOWN, 'JobWithSetupAndTeardown'),
     )
-    def test_basic_directory_configs_end_to_end(self, test_job_config):
+    def test_basic_directory_configs_end_to_end(self, test_job_config, job_name):
         master = self.cluster.start_master()
         slave = self.cluster.start_slave()
 
         project_dir = tempfile.TemporaryDirectory()
         build_resp = master.post_new_build({
             'type': 'directory',
-            'config': test_job_config.config[os.name],
+            'config': yaml.safe_load(test_job_config.config[os.name])[job_name],
             'project_directory': project_dir.name,
         })
         build_id = build_resp['build_id']

--- a/test/unit/project_type/test_project_type.py
+++ b/test/unit/project_type/test_project_type.py
@@ -241,6 +241,22 @@ class TestProjectType(BaseUnitTestCase):
         self.mock_popen.wait.side_effect = fake_wait
         self.mock_popen.returncode = fake_returncode
 
+    def test_job_config_uses_passed_in_config_instead_of_clusterrunner_yaml(self):
+        config_dict = {
+            'commands': ['shell command 1', 'shell command 2;'],
+            'atomizers': [{'TESTPATH': 'atomizer command'}],
+            'max_executors': 100,
+            'max_executors_per_slave': 2,
+        }
+        project_type = ProjectType(config=config_dict, job_name='some_job_name')
+
+        job_config = project_type.job_config()
+
+        self.assertEquals(job_config.name, 'some_job_name')
+        self.assertEquals(job_config.command, 'shell command 1 && shell command 2')
+        self.assertEquals(job_config.max_executors, 100)
+        self.assertEquals(job_config.max_executors_per_slave, 2)
+
 
 class _FakeEnvWithoutDefaultArgs(ProjectType):
     def __init__(self, earth, wind, water, fire, heart):


### PR DESCRIPTION
An example of what the JSON params look like when making a git-type build request:
```php
$params = [
        'type' => 'git',
        'url' => 'ssh://path.to.source.control/projectname',
        'branch' => 'master',
        'job_name' => 'CustomJobNameDoesntMatter',
        'config' => [
            'setup_build' => [
                'do some setup 1',
                'do some setup 2',
            ],
            'commands' => [
                'run some commands 1',
                'run some commands 2',
            ],
            'atomizers' => [
                [ 'TESTPATH' => 'find $PROJECT_DIR/ -name ...' ]
            ],
            'max_executors' => 100,
        ]
];
```