### PR TITLE
Build refactor - Use FSM to track build state

### DIFF
--- a/app/master/build_fsm.py
+++ b/app/master/build_fsm.py
@@ -1,0 +1,200 @@
+from enum import Enum
+import time
+
+from fysom import Fysom, FysomError
+# WIP(joey): Fysom is not thread safe -- multiple threads could theoretically traverse
+# WIP(joey): the same state transition simultaneously.
+
+from app.util import log
+
+
+class BuildState(str, Enum):
+    """Posssible states for the FSM"""
+    QUEUED = 'QUEUED'
+    PREPARING = 'PREPARING'
+    PREPARED = 'PREPARED'
+    BUILDING = 'BUILDING'
+    FINISHED = 'FINISHED'
+    ERROR = 'ERROR'
+    CANCELED = 'CANCELED'
+
+
+class BuildEvent(str, Enum):
+    """Events that correspond to FSM state transitions"""
+    START_PREPARE = 'START_PREPARE'
+    FINISH_PREPARE = 'FINISH_PREPARE'
+    START_BUILDING = 'START_BUILDING'
+    POSTBUILD_TASKS_COMPLETE = 'POSTBUILD_TASKS_COMPLETE'
+    FAIL = 'FAIL'
+    CANCEL = 'CANCEL'
+
+
+class BuildFsm(object):
+    """
+                          +--------+
+      (initial state) >>> | QUEUED |-----+
+                          +--------+     |
+                               |         |
+                 START_PREPARE |         |                   CANCEL
+                               v         |               START_PREPARE
+                        +-----------+    |               FINISH_PREPARE
+                        | PREPARING |----|                 +-------+
+                        +-----------+    |                 |       |
+                               |         |  CANCEL  +----------+   |
+                FINISH_PREPARE |         |--------->| CANCELED |<--+
+                               v         |          +----------+
+                         +----------+    |                 |
+                         | PREPARED |----|                 |
+                         +----------+    |                 | FAIL
+                               |         |                 v
+                START_BUILDING |         |   FAIL   +---------+
+                               v         |-----+--->|  ERROR  |<--+
+                         +----------+    |     |    +---------+   |
+                         | BUILDING |----+     |          |       |
+                         +----------+          |          +-------+
+                               |               |             FAIL
+      POSTBUILD_TASKS_COMPLETE |               |            CANCEL
+                               v               |
+                         +----------+          |
+                     +-->| FINISHED |----------+
+                     |   +----------+
+                     |         |
+                     +---------+
+                        CANCEL
+    """
+    def __init__(self, build_id, enter_state_callbacks):
+        """
+        :type build_id: int
+        :type enter_state_callbacks: dict[BuildState, callable]
+        """
+        self._logger = log.get_logger(__name__)
+        self._build_id = build_id
+        self._transition_timestamps = {state: None for state in BuildState}   # initialize all timestamps to None
+        self._fsm = self._create_state_machine()
+
+        for build_state, callback in enter_state_callbacks.items():
+            self._register_enter_state_callback(build_state, callback)
+
+    def _create_state_machine(self):
+        """
+        Create the Fysom object and set up transitions and states. Note that the first transition
+        (none ==> initial) is triggered immediately on instantiation.
+        :rtype: Fysom
+        """
+        return Fysom({
+            'initial': BuildState.QUEUED,
+            'events': [
+                {'name': BuildEvent.START_PREPARE,
+                 'src': BuildState.QUEUED,
+                 'dst': BuildState.PREPARING},
+
+                {'name': BuildEvent.FINISH_PREPARE,
+                 'src': BuildState.PREPARING,
+                 'dst': BuildState.PREPARED},
+
+                {'name': BuildEvent.START_BUILDING,
+                 'src': BuildState.PREPARED,
+                 'dst': BuildState.BUILDING},
+
+                {'name': BuildEvent.POSTBUILD_TASKS_COMPLETE,
+                 'src': BuildState.BUILDING,
+                 'dst': BuildState.FINISHED},
+
+                {'name': BuildEvent.CANCEL,
+                 'src': [
+                     BuildState.QUEUED,
+                     BuildState.PREPARING,
+                     BuildState.PREPARED,
+                     BuildState.BUILDING,
+                 ],
+                 'dst': BuildState.CANCELED},
+
+                {'name': BuildEvent.FAIL,
+                 'src': '*',  # '*' means this transition can happen from any state.
+                 'dst': BuildState.ERROR},
+
+                # Cancellation immediately after request might cause this transition.
+                {'name': BuildEvent.START_PREPARE,
+                 'src': BuildState.CANCELED,
+                 'dst': '='},  # '=' means the destination state is the same as the source state (no-op).
+
+                # Cancellation during PREPARING will cause this transition.
+                {'name': BuildEvent.FINISH_PREPARE,
+                 'src': BuildState.CANCELED,
+                 'dst': '='},
+
+                # CANCEL is a no-op for a few states.
+                {'name': BuildEvent.CANCEL,
+                 'src': [
+                     BuildState.CANCELED,
+                     BuildState.ERROR,
+                     BuildState.FINISHED,
+                 ],
+                 'dst': '='},
+            ],
+            'callbacks': {
+                'onchangestate': self._record_state_timestamp,
+            }
+        })
+
+    @property
+    def state(self):
+        """
+        The current state of the state machine.
+        :rtype: BuildState
+        """
+        return self._fsm.current
+
+    @property
+    def transition_timestamps(self):
+        """
+        Return a dict of BuildState to the timestamp that the state machine entered that state.
+        :rtype: dict[BuildState, float|None]
+        """
+        return self._transition_timestamps.copy()  # return a copy to prevent external modification
+
+    def trigger(self, build_event, __trigger_fail_on_error=True, **kwargs):
+        """
+        Trigger the specified event to make the state machine transition to a new state.
+
+        :param build_event:
+        :type build_event: BuildEvent
+        :param __trigger_fail_on_error: Whether to make a recursive call in the case of failure -- this
+            exists only for this method's internal use to prevent infinite recursion.
+        :type __trigger_fail_on_error: bool
+        :param kwargs: Parameters that will be attached to the event which is passed to callbacks
+        :type kwargs: dict
+        """
+        try:
+            self._fsm.trigger(build_event, **kwargs)
+
+        except FysomError as ex:
+            # Don't raise transition errors; just fail the build.
+            self._logger.exception('Error during build state transition.')
+            if __trigger_fail_on_error:
+                error_msg = 'Error during build state transition. ({}: {})'.format(type(ex).__name__, ex)
+                self.trigger(BuildEvent.FAIL, error_msg=error_msg, __trigger_fail_on_error=False)
+            else:
+                self._logger.critical('Build attempted to move to ERROR state but the transition itself failed!')
+
+    def _register_enter_state_callback(self, build_state, callback):
+        """
+        Register a callback that will be executed by Fysom when the specified state is entered. This
+        leverages Fysom magic which calls methods by name using a convention ("onenter<state_name>").
+
+        :type build_state: BuildState
+        :type callback: callable
+        """
+        setattr(self._fsm, 'onenter' + build_state, callback)
+
+    def _record_state_timestamp(self, event):
+        """
+        Record a timestamp for a given build status. This is used to record the timing of the various
+        build phases and is exposed via the Build object's API representation.
+        """
+        self._logger.debug('Build {} transitioned from {} to {}', self._build_id, event.src, event.dst)
+        build_state = event.dst
+        if self._transition_timestamps.get(build_state) is not None:
+            self._logger.warning(
+                'Overwriting timestamp for build {}, state {}'.format(self._build_id, build_state))
+        self._transition_timestamps[build_state] = time.time()

--- a/app/master/build_request_handler.py
+++ b/app/master/build_request_handler.py
@@ -13,7 +13,7 @@ class BuildRequestHandler(object):
 
     Implementation notes:
 
-    This class manages two critical Queue's in ClusterRunner: request_queue and builds_waiting_for_slaves.
+    This class manages two critical Queues in ClusterRunner: request_queue and builds_waiting_for_slaves.
 
     The request_queue is the queue of non-prepared Build instances that the BuildRequestHandler has
     yet to prepare. This queue is populated by the ClusterMaster instance.
@@ -107,6 +107,6 @@ class BuildRequestHandler(object):
                     self._builds_waiting_for_slaves.put(build)
 
             except Exception as ex:  # pylint: disable=broad-except
-                build.mark_failed(str(ex))
+                build.mark_failed(str(ex))  # WIP(joey): Build should do this internally.
                 self._logger.exception('Could not handle build request for build {}.'.format(build.build_id()))
                 analytics.record_event(analytics.BUILD_PREPARE_FINISH, build_id=build.build_id(), is_success=False)

--- a/app/master/build_scheduler_pool.py
+++ b/app/master/build_scheduler_pool.py
@@ -21,7 +21,7 @@ class BuildSchedulerPool(object):
         with self._scheduler_creation_lock:
             scheduler = self._schedulers_by_build_id.get(build.build_id())
             if scheduler is None:
-                # WIP: clean up old schedulers (search through list and remove any with finished builds)
+                # WIP(joey): clean up old schedulers (search through list and remove any with finished builds)
                 scheduler = BuildScheduler(build)
                 self._schedulers_by_build_id[build.build_id()] = scheduler
 

--- a/app/master/cluster_master.py
+++ b/app/master/cluster_master.py
@@ -230,7 +230,7 @@ class ClusterMaster(ClusterService):
         if build_request.is_valid():
             build = Build(build_request)
             self._all_builds_by_id[build.build_id()] = build
-            build.generate_project_type()
+            build.generate_project_type()  # WIP(joey): This should be internal to the Build object.
             self._build_request_handler.handle_build_request(build)
             response = {'build_id': build.build_id()}
             success = True
@@ -274,7 +274,7 @@ class ClusterMaster(ClusterService):
         build = self._all_builds_by_id[int(build_id)]
         slave = self._all_slaves_by_url[slave_url]
         # If the build has been canceled, don't work on the next subjob.
-        if not build.is_finished:
+        if not build.is_finished:  # WIP(joey): This check should be internal to the Build object.
             try:
                 build.complete_subjob(subjob_id, payload)
             finally:

--- a/app/util/unhandled_exception_handler.py
+++ b/app/util/unhandled_exception_handler.py
@@ -47,7 +47,7 @@ class UnhandledExceptionHandler(Singleton):
         try:
             signal.signal(self.SIGINFO, self._application_info_dump_signal_handler)
         except ValueError:
-            self._logger.warning('Failed at registering signal handler for SIGINFO. This is expected if ClusterRunner'
+            self._logger.warning('Failed to register signal handler for SIGINFO. This is expected if ClusterRunner '
                                  'is running on Windows.')
 
     @classmethod

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,11 @@
-
 # Install with "pip install -r requirements.txt"
 
 configobj==5.0.6
 coverage==3.7.1
 cx_Freeze==4.3.3
+fysom==2.1.2
 genty==1.1.0
+hypothesis==1.9.0
 Logbook==0.7.0
 nose==1.3.4
 nosexcover==1.0.10
@@ -15,4 +16,3 @@ PyYAML==3.11
 requests==2.3.0
 termcolor==1.1.0
 tornado==3.2.2
-hypothesis==1.9.0

--- a/test/functional/master/test_endpoints.py
+++ b/test/functional/master/test_endpoints.py
@@ -19,6 +19,7 @@ class TestMasterEndpoints(BaseFunctionalTestCase):
 
     def test_cancel_build(self):
         master, build_id = self._start_master_only_and_post_a_new_job()
+
         master.cancel_build(build_id)
         master.block_until_build_finished(build_id)
 
@@ -26,8 +27,10 @@ class TestMasterEndpoints(BaseFunctionalTestCase):
 
     def test_get_artifact_before_it_is_ready(self):
         master, build_id = self._start_master_only_and_post_a_new_job()
+
         # Since we didn't start any slaves so the artifacts is actually not ready.
         _, status_code = master.get_build_artifacts(build_id)
         self.assertEqual(status_code, 202)
 
-
+        # Cancel the started build just to speed up teardown (avoid teardown timeout waiting for empty queue)
+        master.cancel_build(build_id)

--- a/test/unit/master/test_cluster_master.py
+++ b/test/unit/master/test_cluster_master.py
@@ -187,7 +187,7 @@ class TestClusterMaster(BaseUnitTestCase):
         build_id = 1
         slave_url = "url"
         build = Build(BuildRequest({}))
-        build._is_canceled = True
+        build.cancel()
         self.patch_object(build, '_handle_subjob_payload')
         self.patch_object(build, '_mark_subjob_complete')
 

--- a/test/unit/master/test_subjob_calculator.py
+++ b/test/unit/master/test_subjob_calculator.py
@@ -1,5 +1,4 @@
 from unittest.mock import Mock
-from app.master.build_scheduler_pool import BuildSchedulerPool
 
 from genty import genty, genty_dataset
 

--- a/test/unit/util/test_network.py
+++ b/test/unit/util/test_network.py
@@ -84,7 +84,7 @@ class TestNetwork(BaseUnitTestCase):
         self._patch_socket_gethostbyname(side_effect=side_effect)
         self.assertEqual(Network.are_hosts_same(*host_to_id), expect_hosts_are_same)
 
-    def test_get_host_id_of_localhost(self):
+    def test_get_host_id_of_localhost(self):  # todo: this is an integration test -- move it to integration dir
         local_host_name = socket.gethostname()
         self.assertEqual(
             Network.get_host_id('localhost'),


### PR DESCRIPTION
- Add an FSM implementation (based on Fysom) to track the state of a 
build.
- Remove a bunch of flags related to tracking state from the Build
class and use the FSM instead.
- Fix tests.

I've left a bunch of WIP (work-in-progess) notes since this is part of a much larger refactoring and I didn't want to do it all in one commit.
