### PR TITLE
Bump pylint to 1.5.1

### DIFF
--- a/app/client/service_runner.py
+++ b/app/client/service_runner.py
@@ -1,6 +1,7 @@
-import requests
 from subprocess import DEVNULL
 import time
+
+import requests
 
 from app.util.conf.configuration import Configuration
 from app.util.log import get_logger

--- a/app/master/slave.py
+++ b/app/master/slave.py
@@ -1,10 +1,11 @@
+import requests.exceptions
+
 from app.util import analytics, log
 from app.util.counter import Counter
 from app.util.network import Network
 from app.util.safe_thread import SafeThread
 from app.util.secret import Secret
 from app.util.url_builder import UrlBuilder
-import requests.exceptions
 
 
 class Slave(object):

--- a/app/master/subjob_calculator.py
+++ b/app/master/subjob_calculator.py
@@ -42,12 +42,11 @@ class SubjobCalculator(object):
 
         # Generate subjobs for each group of atoms
         subjobs = []
-        for subjob_id in range(len(grouped_atoms)):
-            atoms = grouped_atoms[subjob_id]
-            # The atom id's aren't calculated until it's been assigned grouped in a subjob.
-            for idx, atom in enumerate(atoms):
-                atom.id = idx
-            subjobs.append(Subjob(build_id, subjob_id, project_type, job_config, atoms))
+        for subjob_id, subjob_atoms in enumerate(grouped_atoms):
+            # The atom id isn't calculated until the atom has been grouped into a subjob.
+            for atom_id, atom in enumerate(subjob_atoms):
+                atom.id = atom_id
+            subjobs.append(Subjob(build_id, subjob_id, project_type, job_config, subjob_atoms))
         return subjobs
 
     def _grouped_atoms(self, atoms, max_executors, timing_file_path, project_directory):

--- a/app/slave/cluster_slave.py
+++ b/app/slave/cluster_slave.py
@@ -1,8 +1,9 @@
 from enum import Enum
 from queue import Queue
-import requests
 import sys
 import time
+
+import requests
 
 from app.common.cluster_service import ClusterService
 from app.project_type.project_type import SetupFailureError
@@ -52,6 +53,7 @@ class ClusterSlave(ClusterService):
         self._project_type = None  # this will be instantiated during build setup
         self._current_build_id = None
         self._build_teardown_coin = None
+        self._base_executor_index = None
 
     def api_representation(self):
         """
@@ -184,6 +186,7 @@ class ClusterSlave(ClusterService):
         self._logger.info('Build teardown complete for build {}.', self._current_build_id)
         self._current_build_id = None
         self._project_type = None
+        self._base_executor_index = None
 
     def _send_master_idle_notification(self):
         if not self._is_master_responsive():

--- a/app/subcommands/deploy_subcommand.py
+++ b/app/subcommands/deploy_subcommand.py
@@ -2,9 +2,10 @@ import getpass
 from multiprocessing.dummy import Pool
 import os
 from os.path import join
-import requests
 import sys
 from urllib.parse import urlparse
+
+import requests
 
 from app.client.build_runner import BuildRunner
 from app.deployment.deploy_target import DeployTarget

--- a/app/util/conf/base_config_loader.py
+++ b/app/util/conf/base_config_loader.py
@@ -178,7 +178,7 @@ class BaseConfigLoader(object):
 
         if isinstance(default_value, bool):  # bool is a subclass of int so should be checked first
             value_mapping = {'true': True, 'false': False}
-            if not isinstance(value, str) and not value.lower() in value_mapping.keys():
+            if not isinstance(value, str) and value.lower() not in value_mapping.keys():
                 raise InvalidConfigError('The value for {} should be True or False, but it is "{}"'.format(key, value))
             config.set(key, value_mapping[value.lower()])
 

--- a/app/util/conf/config_file.py
+++ b/app/util/conf/config_file.py
@@ -1,6 +1,7 @@
-from configobj import ConfigObj
 import os
 import stat
+
+from configobj import ConfigObj
 
 from app.util import fs
 from app.util.process_utils import is_windows

--- a/app/util/event_log.py
+++ b/app/util/event_log.py
@@ -1,15 +1,15 @@
 import collections
 import json
-from logbook import RotatingFileHandler, StreamHandler
-from logbook.more import TaggingHandler, TaggingLogger
 import os
 import sys
 import time
 
+from logbook import RotatingFileHandler, StreamHandler
+from logbook.more import TaggingHandler, TaggingLogger
+
 from app.util import fs, log
 from app.util.conf.configuration import Configuration
 from app.util.counter import Counter
-
 
 LOG_CACHE_EXPIRE_TIME_IN_HOURS = 5
 LOG_CACHE_THRESHOLD = 100000

--- a/app/util/log.py
+++ b/app/util/log.py
@@ -1,12 +1,13 @@
 from collections import defaultdict
-import logbook
-from logbook import Logger, NullHandler, RotatingFileHandler, StreamHandler
-import logbook.compat
 import logging
 import os
 import sys
-from termcolor import colored
 import threading
+
+import logbook
+from logbook import Logger, NullHandler, RotatingFileHandler, StreamHandler
+import logbook.compat
+from termcolor import colored
 
 from app.util import autoversioning, fs
 from app.util.conf.configuration import Configuration

--- a/app/util/network.py
+++ b/app/util/network.py
@@ -1,12 +1,12 @@
 import json
+import socket
+
 import requests
 from requests.adapters import HTTPAdapter, DEFAULT_POOLSIZE
-import socket
 
 from app.util.decorators import retry_on_exception_exponential_backoff
 from app.util.log import get_logger
 from app.util.secret import Secret
-
 
 ENCODED_BODY = '__encoded_body__'
 

--- a/app/web_framework/cluster_base_handler.py
+++ b/app/web_framework/cluster_base_handler.py
@@ -9,6 +9,9 @@ from app.util.exceptions import AuthenticationError, BadRequestError, ItemNotFou
 from app.util.network import ENCODED_BODY
 
 
+# pylint: disable=attribute-defined-outside-init
+#   Handler classes are not designed to have __init__ overridden.
+
 class ClusterBaseHandler(tornado.web.RequestHandler):
     """
     ClusterBaseHandler is the base handler for all request handlers of ClusterRunner services.

--- a/app/web_framework/cluster_master_application.py
+++ b/app/web_framework/cluster_master_application.py
@@ -1,7 +1,8 @@
 import http.client
 import os
-import tornado.web
 import urllib.parse
+
+import tornado.web
 
 from app.util import analytics
 from app.util import log
@@ -14,6 +15,9 @@ from app.web_framework.cluster_application import ClusterApplication
 from app.web_framework.cluster_base_handler import ClusterBaseAPIHandler, ClusterBaseHandler
 from app.web_framework.route_node import RouteNode
 
+
+# pylint: disable=attribute-defined-outside-init
+#   Handler classes are not designed to have __init__ overridden.
 
 class ClusterMasterApplication(ClusterApplication):
 

--- a/app/web_framework/route_node.py
+++ b/app/web_framework/route_node.py
@@ -46,7 +46,7 @@ class RouteNode(object):
         # for the handler's get() method
         if self.regex_part.startswith('('):
             if hasattr(self.handler, 'get'):
-                get_params = inspect.getargspec(self.handler.get).args
+                get_params = inspect.getargspec(self.handler.get).args  # pylint: disable=deprecated-method
                 if len(get_params) > 1:
                     return '[{}]'.format(get_params[-1])
         return self.regex_part

--- a/pylintrc
+++ b/pylintrc
@@ -7,9 +7,6 @@
 # pygtk.require().
 #init-hook=
 
-# Profiled execution.
-profile=no
-
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
 ignore=CVS
@@ -21,7 +18,32 @@ persistent=yes
 # usually to register additional checkers.
 load-plugins=
 
+# Use multiple processes to speed up Pylint.
+jobs=1
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-whitelist=
+
+# Allow optimization of some AST trees. This will activate a peephole AST
+# optimizer, which will apply various small optimizations. For instance, it can
+# be used to obtain the result of joining multiple strings with the addition
+# operator. Joining a lot of strings can lead to a maximum recursion error in
+# Pylint and this flag can prevent that. It has one side effect, the resulting
+# AST will be different than the one from reality.
+optimize-ast=no
+
+
 [MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
@@ -38,8 +60,7 @@ load-plugins=
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
 
-disable=R, missing-docstring, fixme, invalid-name, bad-continuation, attribute-defined-outside-init, arguments-differ,
-    attribute-defined-outside-init, star-args, locally-disabled, unused-argument, unused-variable, no-init,
+disable=R, missing-docstring, fixme, invalid-name, arguments-differ, locally-disabled, unused-argument, unused-variable,
     global-statement,
 
 [REPORTS]
@@ -64,10 +85,6 @@ reports=no
 # (RP0004).
 evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
 
-# Add a comment according to your evaluation note. This is used by the global
-# evaluation report (RP0004).
-comment=no
-
 # Template used to display messages. This is a python new-style format string
 # used to format the message information. See doc for all details
 #msg-template=
@@ -75,11 +92,8 @@ comment=no
 
 [BASIC]
 
-# Required attributes for module, separated by a comma
-required-attributes=
-
 # List of builtins function names that should not be used, separated by a comma
-bad-functions=map,filter,apply
+bad-functions=map,filter
 
 # Good variable names which should always be accepted, separated by a comma
 good-names=i,j,k,ex,Run,_
@@ -94,35 +108,11 @@ name-group=
 # Include a hint for the correct naming format with invalid-name
 include-naming-hint=no
 
-# Regular expression matching correct argument names
-argument-rgx=[a-z_][a-z0-9_]{2,30}$
-
-# Naming hint for argument names
-argument-name-hint=[a-z_][a-z0-9_]{2,30}$
-
-# Regular expression matching correct inline iteration names
-inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
-
-# Naming hint for inline iteration names
-inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
-
-# Regular expression matching correct variable names
-variable-rgx=[a-z_][a-z0-9_]{2,30}$
-
-# Naming hint for variable names
-variable-name-hint=[a-z_][a-z0-9_]{2,30}$
-
 # Regular expression matching correct class names
 class-rgx=[A-Z_][a-zA-Z0-9]+$
 
 # Naming hint for class names
 class-name-hint=[A-Z_][a-zA-Z0-9]+$
-
-# Regular expression matching correct constant names
-const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
-
-# Naming hint for constant names
-const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
 
 # Regular expression matching correct class attribute names
 class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
@@ -130,17 +120,11 @@ class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
 # Naming hint for class attribute names
 class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
 
-# Regular expression matching correct attribute names
-attr-rgx=[a-z_][a-z0-9_]{2,30}$
+# Regular expression matching correct variable names
+variable-rgx=[a-z_][a-z0-9_]{2,30}$
 
-# Naming hint for attribute names
-attr-name-hint=[a-z_][a-z0-9_]{2,30}$
-
-# Regular expression matching correct method names
-method-rgx=[a-z_][a-z0-9_]{2,30}$
-
-# Naming hint for method names
-method-name-hint=[a-z_][a-z0-9_]{2,30}$
+# Naming hint for variable names
+variable-name-hint=[a-z_][a-z0-9_]{2,30}$
 
 # Regular expression matching correct module names
 module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
@@ -154,13 +138,49 @@ function-rgx=[a-z_][a-z0-9_]{2,30}$
 # Naming hint for function names
 function-name-hint=[a-z_][a-z0-9_]{2,30}$
 
+# Regular expression matching correct constant names
+const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Naming hint for constant names
+const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Regular expression matching correct inline iteration names
+inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
+
+# Naming hint for inline iteration names
+inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
+
+# Regular expression matching correct argument names
+argument-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for argument names
+argument-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct attribute names
+attr-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for attribute names
+attr-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct method names
+method-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for method names
+method-name-hint=[a-z_][a-z0-9_]{2,30}$
+
 # Regular expression which should only match function or class names that do
 # not require a docstring.
-no-docstring-rgx=__.*__
+no-docstring-rgx=^_
 
 # Minimum line length for functions/classes that require docstrings, shorter
 # ones are exempt.
 docstring-min-length=-1
+
+
+[ELIF]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
 
 
 [FORMAT]
@@ -175,18 +195,24 @@ ignore-long-lines=^\s*(# )?<?https?://\S+>?$
 # else.
 single-line-if-stmt=no
 
-# List of optional constructs for which whitespace checking is disabled
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
 no-space-check=trailing-comma,dict-separator
 
 # Maximum number of lines in a module
 max-module-lines=1000
 
-# String used as indentation unit. This is usually " " (4 spaces) or "\t" (1
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
 # tab).
 indent-string='    '
 
-# Number of spaces of indent required inside a hanging or continued line.
+# Number of spaces of indent required inside a hanging  or continued line.
 indent-after-paren=4
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
 
 
 [LOGGING]
@@ -217,6 +243,23 @@ ignore-docstrings=yes
 ignore-imports=no
 
 
+[SPELLING]
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
 [TYPECHECK]
 
 # Tells whether missing members accessed in mixin class should be ignored. A
@@ -225,21 +268,19 @@ ignore-mixin-members=yes
 
 # List of module names for which member attributes should not be checked
 # (useful for modules/projects where namespaces are manipulated during runtime
-# and thus existing member attributes cannot be deduced by static analysis
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
 ignored-modules=
 
 # List of classes names for which member attributes should not be checked
-# (useful for classes with attributes dynamically set).
-ignored-classes=SQLObject
-
-# When zope mode is activated, add a predefined set of Zope acquired attributes
-# to generated-members.
-zope=no
+# (useful for classes with attributes dynamically set). This supports can work
+# with qualified names.
+ignored-classes=
 
 # List of members which are set dynamically and missed by pylint inference
-# system, and so shouldn't trigger E0201 when accessed. Python regular
+# system, and so shouldn't trigger E1101 when accessed. Python regular
 # expressions are accepted.
-generated-members=REQUEST,acl_users,aq_parent
+generated-members=
 
 
 [VARIABLES]
@@ -255,12 +296,12 @@ dummy-variables-rgx=_$|dummy
 # you should avoid to define new builtins when possible.
 additional-builtins=
 
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,_cb
+
 
 [CLASSES]
-
-# List of interface methods to ignore, separated by a comma. This is used for
-# instance to not check methods defines in Zope's Interface base class.
-ignore-iface-methods=isImplementedBy,deferred,extends,names,namesAndDescriptions,queryDescriptionFor,getBases,getDescriptionFor,getDoc,getName,getTaggedValue,getTaggedValueTags,isEqualOrExtendedBy,setTaggedValue,isImplementedByInstancesOf,adaptWith,is_implemented_by
 
 # List of method names used to declare (i.e. assign) instance attributes.
 defining-attr-methods=__init__,__new__,setUp
@@ -270,6 +311,10 @@ valid-classmethod-first-arg=cls
 
 # List of valid names for the first argument in a metaclass class method.
 valid-metaclass-classmethod-first-arg=mcs
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,_fields,_replace,_source,_make
 
 
 [DESIGN]
@@ -305,11 +350,14 @@ min-public-methods=2
 # Maximum number of public methods for a class (see R0904).
 max-public-methods=20
 
+# Maximum number of boolean expressions in a if statement
+max-bool-expr=5
+
 
 [IMPORTS]
 
 # Deprecated modules which should not be used, separated by a comma
-deprecated-modules=stringprep,optparse
+deprecated-modules=optparse
 
 # Create a graph of every (i.e. internal and external) dependencies in the
 # given file (report RP0402 must not be disabled)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ nose==1.3.4
 nosexcover==1.0.10
 pep8==1.5.7
 psutil==2.1.2
-pylint==1.4.2
+pylint==1.5.1
 PyYAML==3.11
 requests==2.3.0
 termcolor==1.1.0


### PR DESCRIPTION
This fixes currently failing lint jobs. I also regenerated the
pylintrc file (`pylint --generate-rcfile`) and added back some of our
custom rule ignores.

Pylint 1.4.2 has an incompatibility with the newest version of one of
its dependencies (astroid). This has started causing our lint jobs to
fail with a bunch of errors that look like:

```
E: 37, 8: Undefined variable 'self' (undefined-variable)
```

Since we have only specified exact versions of our dependencies in
requirements.txt (and not the exact versions of dependencies'
dependencies, etc.) it's still possible for third party libraries to
break something without a change on our side.

We should switch over to using peep
(https://pypi.python.org/pypi/peep) or something similar.