### PR TITLE
Fix delay in windows functional tests

### DIFF
--- a/test/functional/job_configs.py
+++ b/test/functional/job_configs.py
@@ -118,18 +118,18 @@ JobWithSetupAndTeardown:
 
 """,
         'nt': """
-        # sleep 1 is replaced by ping 127.0.0.1 -n 1 to generate a small amount of delay.
+        # sleep 1 is replaced by ping 127.0.0.1 -n 2 to generate a small amount of delay.
         # I didn't use 'timeout /t 1' since it would fail with "ERROR: Input redirection is not supported,
         # exiting the process immediately."
 JobWithSetupAndTeardown:
     setup_build:
         - echo Doing build setup.
-        - ping 127.0.0.1 -n 1
+        - ping 127.0.0.1 -n 2
         - echo setup.> !PROJECT_DIR!\\build_setup.txt
 
     commands:
         - echo Doing subjob !SUBJOB_NUMBER!.
-        - ping 127.0.0.1 -n 1
+        - ping 127.0.0.1 -n 2
         - set MY_SUBJOB_FILE=!PROJECT_DIR!\\subjob_file_!SUBJOB_NUMBER!.txt
         - COPY build_setup.txt !MY_SUBJOB_FILE!
         - echo subjob !SUBJOB_NUMBER!.>> !MY_SUBJOB_FILE!
@@ -139,7 +139,7 @@ JobWithSetupAndTeardown:
 
     teardown_build:
         - echo Doing build teardown.
-        - ping 127.0.0.1 -n 1
+        - ping 127.0.0.1 -n 2
         - FOR /l %n in (1,1,3) DO @echo teardown.>> !PROJECT_DIR!\\subjob_file_%n.txt
 """,
     },


### PR DESCRIPTION
The functional tests actually weren't sleeping before. The `ping`
behavior is unintuitive and requires `-n 2` for a 1 second delay.