### PR TITLE
Add SIGINFO logging when service is hard killed

### DIFF
--- a/test/unit/util/test_unhandled_exception_handler.py
+++ b/test/unit/util/test_unhandled_exception_handler.py
@@ -3,6 +3,7 @@ import sys
 from threading import Thread
 from unittest.mock import call, mock_open, MagicMock
 
+from app.util import process_utils
 from test.framework.base_unit_test_case import BaseUnitTestCase
 from test.framework.comparators import AnyStringMatching
 from app.util.unhandled_exception_handler import UnhandledExceptionHandler
@@ -33,7 +34,7 @@ class TestUnhandledExceptionHandler(BaseUnitTestCase):
         mock_signal = self.patch('app.util.unhandled_exception_handler.signal')
 
         def register_signal_handler(sig, _):
-            if sig == UnhandledExceptionHandler.SIGINFO:
+            if sig == process_utils.SIGINFO:
                 raise ValueError
         mock_signal.signal.side_effect = register_signal_handler
         UnhandledExceptionHandler.singleton()
@@ -145,7 +146,7 @@ class TestUnhandledExceptionHandler(BaseUnitTestCase):
     def test_application_info_dump_signal_handler_writes_to_file(self):
         open_mock = mock_open()
         self.patch('app.util.unhandled_exception_handler.open', new=open_mock, create=True)
-        self.exception_handler._application_info_dump_signal_handler(UnhandledExceptionHandler.SIGINFO, MagicMock())
+        self.exception_handler._application_info_dump_signal_handler(process_utils.SIGINFO, MagicMock())
 
         handle = open_mock()
         assert handle.write.called


### PR DESCRIPTION
The functional testing framework sometimes is unable to kill and
restart the service gracefully in between tests. This change sends a
SIGINFO signal before doing the hard kill. The debug logs triggered by
this signal should give us info about what thread is preventing
graceful shutdown.