### PR TITLE
If no atoms to run, then exit the build preparation phase before slave

### DIFF
--- a/app/master/build_request_handler.py
+++ b/app/master/build_request_handler.py
@@ -102,13 +102,16 @@ class BuildRequestHandler(object):
             try:
                 build.prepare(self._subjob_calculator)
                 if not build.has_error:
+                    analytics.record_event(analytics.BUILD_PREPARE_FINISH, build_id=build.build_id(), is_success=True,
+                                           log_msg='Build {build_id} successfully prepared.')
                     # If the atomizer found no work to do, perform build cleanup and skip the slave allocation.
                     if len(build.all_subjobs()) == 0:
                         self._logger.info('Build {} has no work to perform and is exiting.', build.build_id())
                         build.finish()
-                    analytics.record_event(analytics.BUILD_PREPARE_FINISH, build_id=build.build_id(), is_success=True,
-                                           log_msg='Build {build_id} successfully prepared and waiting for slaves.')
-                    self._builds_waiting_for_slaves.put(build)
+                    # If there is work to be done, this build must queue to be allocated slaves.
+                    else:
+                        self._logger.info('Build {} is waiting for slaves.', build.build_id())
+                        self._builds_waiting_for_slaves.put(build)
 
             except Exception as ex:  # pylint: disable=broad-except
                 build.mark_failed(str(ex))  # WIP(joey): Build should do this internally.

--- a/test/unit/master/test_build_request_handler.py
+++ b/test/unit/master/test_build_request_handler.py
@@ -1,0 +1,26 @@
+from genty import genty, genty_dataset
+
+from app.master.build_request_handler import BuildRequestHandler
+from test.framework.base_unit_test_case import BaseUnitTestCase
+
+
+@genty
+class TestBuildRequestHandler(BaseUnitTestCase):
+    @genty_dataset(
+        no_subjobs=([], True),
+        one_subjob=(['some subjob'], False),
+    )
+    def test_prepare_build_async_calls_finish_only_if_no_subjobs(self, subjobs, build_finish_called):
+        mock_project_lock = self.patch('threading.Lock').return_value
+        build_scheduler_mock = self.patch('app.master.build_scheduler.BuildScheduler').return_value
+        build_request_handler = BuildRequestHandler(build_scheduler_mock)
+        build_mock = self.patch('app.master.build.Build').return_value
+        build_mock.has_error = False
+        build_mock.all_subjobs.return_value = subjobs
+
+        build_request_handler._prepare_build_async(build_mock, mock_project_lock)
+
+        if build_finish_called:
+            build_mock.finish.assert_called_once_with()
+        else:
+            self.assertFalse(build_mock.finish.called)


### PR DESCRIPTION
allocation.

Follow up to https://github.com/box/ClusterRunner/pull/286 