### PR TITLE
Delete artifact directory for build on master after completion.

### DIFF
--- a/app/master/build.py
+++ b/app/master/build.py
@@ -2,7 +2,6 @@ from collections import OrderedDict
 from enum import Enum
 import os
 from queue import Queue, Empty
-import shutil
 from threading import Lock
 import uuid
 

--- a/app/master/build.py
+++ b/app/master/build.py
@@ -450,20 +450,20 @@ class Build(object):
         self._build_artifact = BuildArtifact(self._build_results_dir())
         self._build_artifact.generate_failures_file()
         self._build_artifact.write_timing_data(self._timing_file_path, self._read_subjob_timings_from_results())
-        self._artifacts_archive_file = app.util.fs.compress_directory(self._build_results_dir(), 'results.tar.gz')
+        self._artifacts_archive_file = app.util.fs.compress_directory(self._build_results_dir(),
+                                                                      BuildArtifact.ARTIFACT_FILE_NAME)
 
     def _delete_temporary_build_artifact_files(self):
         """
         Delete the temporary build result files that are no longer needed, due to the creation of the
-        build artifact tarball (results.tar.gz).
+        build artifact tarball.
 
         ONLY call this method after _create_build_artifact() has completed. Otherwise we have lost the build results.
         """
         build_result_dir = self._build_results_dir()
         for path in os.listdir(build_result_dir):
-            # The build result tar-ball (results.tar.gz) is also stored in this same directory, so we must
-            # skip deleting it.
-            if path == 'results.tar.gz':
+            # The build result tar-ball is also stored in this same directory, so we must not delete it.
+            if path == BuildArtifact.ARTIFACT_FILE_NAME:
                 continue
             app.util.fs.async_delete(os.path.join(build_result_dir, path))
 

--- a/app/master/build.py
+++ b/app/master/build.py
@@ -466,11 +466,7 @@ class Build(object):
             # skip deleting it.
             if path == 'results.tar.gz':
                 continue
-            full_path = os.path.join(build_result_dir, path)
-            if os.path.isdir(full_path):
-                shutil.rmtree(full_path)
-            else:
-                os.remove(full_path)
+            app.util.fs.async_delete(os.path.join(build_result_dir, path))
 
     def _build_results_dir(self):
         return BuildArtifact.build_artifact_directory(self.build_id(), result_root=Configuration['results_directory'])

--- a/app/master/build_artifact.py
+++ b/app/master/build_artifact.py
@@ -14,6 +14,7 @@ class BuildArtifact(object):
     EXIT_CODE_FILE = 'clusterrunner_exit_code'
     OUTPUT_FILE = 'clusterrunner_console_output'
     TIMING_FILE = 'clusterrunner_time'
+    ARTIFACT_FILE_NAME = 'results.tar.gz'
 
     def __init__(self, build_artifact_dir):
         """

--- a/test/framework/functional/base_functional_test_case.py
+++ b/test/framework/functional/base_functional_test_case.py
@@ -11,6 +11,7 @@ from app.util.fs import create_dir, extract_tar
 from app.util.process_utils import is_windows
 from app.util.network import Network
 from app.util.secret import Secret
+from app.master.build_artifact import BuildArtifact
 from test.framework.functional.fs_item import Directory
 from test.framework.functional.functional_test_cluster import FunctionalTestCluster, TestClusterTimeoutError
 
@@ -182,7 +183,7 @@ class BaseFunctionalTestCase(TestCase):
         :type download_dir: str
         """
         download_artifacts_url = master_api.url('build', build_id, 'result')
-        download_filepath = os.path.join(download_dir, 'results.tar.gz')
+        download_filepath = os.path.join(download_dir, BuildArtifact.ARTIFACT_FILE_NAME)
         response = self._network.get(download_artifacts_url)
 
         if response.status_code == http.client.OK:

--- a/test/framework/functional/base_functional_test_case.py
+++ b/test/framework/functional/base_functional_test_case.py
@@ -1,4 +1,5 @@
 from contextlib import suppress
+import http.client
 import os
 from os import path
 import shutil
@@ -6,7 +7,9 @@ import tempfile
 from unittest import TestCase
 
 from app.util import log
+from app.util.fs import create_dir, extract_tar
 from app.util.process_utils import is_windows
+from app.util.network import Network
 from app.util.secret import Secret
 from test.framework.functional.fs_item import Directory
 from test.framework.functional.functional_test_cluster import FunctionalTestCluster, TestClusterTimeoutError
@@ -25,6 +28,7 @@ class BaseFunctionalTestCase(TestCase):
         Secret.set('testsecret')
 
         self.cluster = FunctionalTestCluster(verbose=self._get_test_verbosity())
+        self._network = Network()
 
     def _create_test_config_file(self, conf_values_to_set=None):
         """
@@ -142,17 +146,19 @@ class BaseFunctionalTestCase(TestCase):
             }
         self.assert_build_status_contains_expected_data(build_id, expected_failure_build_params)
 
-    def assert_build_artifact_contents_match_expected(self, build_id, expected_build_artifact_contents):
+    def assert_build_artifact_contents_match_expected(self, master_api, build_id, expected_build_artifact_contents):
         """
         Assert that artifact files for this build have the expected contents.
 
+        :type master_api: app.util.url_builder.UrlBuilder
         :param build_id: The id of the build whose artifacts to check
         :type build_id: int
         :param expected_build_artifact_contents: A list of FSItems corresponding to the expected artifact dir contents
         :type expected_build_artifact_contents: list[FSItem]
         """
-        build_artifacts_dir_path = os.path.join(self.cluster.master_app_base_dir.name, 'results', 'master', str(build_id))
-        self.assert_directory_contents_match_expected(build_artifacts_dir_path, expected_build_artifact_contents)
+        with tempfile.TemporaryDirectory() as build_artifacts_dir_path:
+            self._download_and_extract_results(master_api, build_id, build_artifacts_dir_path)
+            self.assert_directory_contents_match_expected(build_artifacts_dir_path, expected_build_artifact_contents)
 
     def assert_directory_contents_match_expected(self, dir_path, expected_dir_contents):
         """
@@ -168,3 +174,22 @@ class BaseFunctionalTestCase(TestCase):
             expected_dir_name = os.path.basename(dir_path)
             expected_build_artifacts = Directory(expected_dir_name, expected_dir_contents)
             expected_build_artifacts.assert_matches_path(dir_path, allow_extra_items=False)
+
+    def _download_and_extract_results(self, master_api, build_id, download_dir):
+        """
+        :type master_api: app.util.url_builder.UrlBuilder
+        :type build_id: int
+        :type download_dir: str
+        """
+        download_artifacts_url = master_api.url('build', build_id, 'result')
+        download_filepath = os.path.join(download_dir, 'results.tar.gz')
+        response = self._network.get(download_artifacts_url)
+
+        if response.status_code == http.client.OK:
+            # save tar file to disk, decompress, and delete
+            with open(download_filepath, 'wb') as file:
+                chunk_size = 500 * 1024
+                for chunk in response.iter_content(chunk_size):
+                    file.write(chunk)
+
+            extract_tar(download_filepath, delete=True)

--- a/test/functional/job_configs.py
+++ b/test/functional/job_configs.py
@@ -49,7 +49,6 @@ BasicJob:
         Directory('artifact_2_0', DEFAULT_ATOM_FILES + [File('result.txt', contents='This is atom 2\n')]),
         Directory('artifact_3_0', DEFAULT_ATOM_FILES + [File('result.txt', contents='This is atom 3\n')]),
         Directory('artifact_4_0', DEFAULT_ATOM_FILES + [File('result.txt', contents='This is atom 4\n')]),
-        File('results.tar.gz'),
     ],
 )
 
@@ -83,7 +82,6 @@ BasicFailingJob:
         Directory('artifact_2_0', DEFAULT_ATOM_FILES + [File('result.txt', contents='This is atom 2\n')]),
         Directory('artifact_3_0', DEFAULT_ATOM_FILES),
         Directory('artifact_4_0', DEFAULT_ATOM_FILES + [File('result.txt', contents='This is atom 4\n')]),
-        File('results.tar.gz'),
         File('failures.txt', contents='artifact_3_0'),
     ],
 )

--- a/test/functional/test_cluster_basic.py
+++ b/test/functional/test_cluster_basic.py
@@ -43,7 +43,10 @@ class TestClusterBasic(BaseFunctionalTestCase):
                 'num_atoms': test_job_config.expected_num_atoms,
                 'num_subjobs': test_job_config.expected_num_atoms})
         self.assert_build_artifact_contents_match_expected(
-            build_id=build_id, expected_build_artifact_contents=test_job_config.expected_artifact_contents)
+            master_api=master._api,
+            build_id=build_id,
+            expected_build_artifact_contents=test_job_config.expected_artifact_contents
+        )
         self.assert_directory_contents_match_expected(
             dir_path=project_dir.name, expected_dir_contents=test_job_config.expected_project_dir_contents)
 

--- a/test/functional/test_cluster_basic.py
+++ b/test/functional/test_cluster_basic.py
@@ -5,6 +5,7 @@ import yaml
 
 from genty import genty, genty_dataset
 
+from app.master.build_artifact import BuildArtifact
 from test.framework.functional.base_functional_test_case import BaseFunctionalTestCase
 from test.framework.functional.fs_item import Directory, File
 from test.functional.job_configs import BASIC_FAILING_JOB, BASIC_JOB, JOB_WITH_SETUP_AND_TEARDOWN
@@ -74,7 +75,7 @@ class TestClusterBasic(BaseFunctionalTestCase):
             ])
             for i in range(10)
         ]
-        expected_artifact_contents.append(File('results.tar.gz'))
+        expected_artifact_contents.append(File(BuildArtifact.ARTIFACT_FILE_NAME))
 
         self.assert_build_has_successful_status(build_id=build_id)
         self.assert_build_status_contains_expected_data(

--- a/test/unit/master/test_build.py
+++ b/test/unit/master/test_build.py
@@ -432,7 +432,7 @@ class TestBuild(BaseUnitTestCase):
 
     def test_delete_temporary_build_artifact_files_skips_results_tarball(self):
         build = self._create_test_build(BuildStatus.BUILDING)
-        self.mock_listdir.return_value = ['some_dir1', 'results.tar.gz']
+        self.mock_listdir.return_value = ['some_dir1', BuildArtifact.ARTIFACT_FILE_NAME]
         expected_async_delete_call_path = join(build._build_results_dir(), 'some_dir1')
 
         build._delete_temporary_build_artifact_files()

--- a/test/unit/master/test_build.py
+++ b/test/unit/master/test_build.py
@@ -38,6 +38,8 @@ class TestBuild(BaseUnitTestCase):
         self.patch('app.master.build.BuildArtifact.__new__')  # patch __new__ to mock instances but keep static methods
         self.mock_util = self.patch('app.master.build.app.util')  # stub out util - it often interacts with the fs
         self.mock_open = self.patch('app.master.build.open', autospec=False, create=True)
+        self.mock_rmtree = self.patch('shutil.rmtree')
+        self.mock_listdir = self.patch('os.listdir')
         self.scheduler_pool = BuildSchedulerPool()
 
     def test_allocate_slave_calls_slave_setup(self):
@@ -428,6 +430,15 @@ class TestBuild(BaseUnitTestCase):
             build._all_subjobs_by_id[1]._atoms[1],
             build._all_subjobs_by_id[3]._atoms[3],
         ])
+
+    def test_delete_temporary_build_artifact_files_skips_results_tarball(self):
+        build = self._create_test_build(BuildStatus.BUILDING)
+        self.mock_listdir.return_value = ['some_dir1', 'results.tar.gz']
+        expected_rmtree_call_path = join(build._build_results_dir(), 'some_dir1')
+
+        build._delete_temporary_build_artifact_files()
+
+        self.mock_rmtree.assert_called_once_with(expected_rmtree_call_path)
 
     def _create_test_build(
             self,

--- a/test/unit/master/test_build.py
+++ b/test/unit/master/test_build.py
@@ -38,7 +38,6 @@ class TestBuild(BaseUnitTestCase):
         self.patch('app.master.build.BuildArtifact.__new__')  # patch __new__ to mock instances but keep static methods
         self.mock_util = self.patch('app.master.build.app.util')  # stub out util - it often interacts with the fs
         self.mock_open = self.patch('app.master.build.open', autospec=False, create=True)
-        self.mock_rmtree = self.patch('shutil.rmtree')
         self.mock_listdir = self.patch('os.listdir')
         self.scheduler_pool = BuildSchedulerPool()
 
@@ -434,11 +433,11 @@ class TestBuild(BaseUnitTestCase):
     def test_delete_temporary_build_artifact_files_skips_results_tarball(self):
         build = self._create_test_build(BuildStatus.BUILDING)
         self.mock_listdir.return_value = ['some_dir1', 'results.tar.gz']
-        expected_rmtree_call_path = join(build._build_results_dir(), 'some_dir1')
+        expected_async_delete_call_path = join(build._build_results_dir(), 'some_dir1')
 
         build._delete_temporary_build_artifact_files()
 
-        self.mock_rmtree.assert_called_once_with(expected_rmtree_call_path)
+        self.mock_util.fs.async_delete.assert_called_once_with(expected_async_delete_call_path)
 
     def _create_test_build(
             self,


### PR DESCRIPTION
That directory's contents are no longer needed once the build artifact tarball has been created, and is just taking up disk space and inodes on the master at that point.

https://github.com/box/ClusterRunner/issues/298