### PR TITLE
Perform shallow clones and fetches on both slave and master.

### DIFF
--- a/app/project_type/git.py
+++ b/app/project_type/git.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 from urllib.parse import urlparse
 
 from app.project_type.project_type import ProjectType
@@ -154,28 +153,22 @@ class Git(ProjectType):
         """
         Clones the project if necessary, fetches from the remote repo and resets to the requested commit
         """
-        # For backward compatibility: If a shallow repo exists, delete it.  Shallow cloning is no longer supported,
-        # it causes failures when fetching refs that depend on commits which are excluded from the shallow clone.
-        existing_repo_is_shallow = os.path.isfile(os.path.join(self._repo_directory, '.git', 'shallow'))
-        if existing_repo_is_shallow:
-            if os.path.exists(self._repo_directory):
-                shutil.rmtree(self._repo_directory)
-                fs.create_dir(self._repo_directory, self.DIRECTORY_PERMISSIONS)
-
         # Clone the repo if it doesn't exist
         try:
             self._execute_git_command_in_repo_and_raise_on_failure('rev-parse')  # rev-parse succeeds if repo exists
         except RuntimeError:
             self._logger.notice('No valid repo in "{}". Cloning fresh from "{}".', self._repo_directory, self._url)
+            # Clone with --depth=1 for shallow clones in order to improve performance.
             self._execute_git_command_in_repo_and_raise_on_failure(
-                git_command='clone {} {}'. format(self._url, self._repo_directory),
+                git_command='clone --depth=1 {} {}'. format(self._url, self._repo_directory),
                 error_msg='Could not clone repo.'
             )
 
         # Must add the --update-head-ok in the scenario that the current branch of the working directory
         # is equal to self._branch, otherwise the git fetch will exit with a non-zero exit code.
+        # Must add the --depth=1 in order to have shallow fetches in order to improve performance.
         self._execute_git_command_in_repo_and_raise_on_failure(
-            git_command='fetch --update-head-ok {} {}'.format(self._remote, self._branch),
+            git_command='fetch --depth=1 --update-head-ok {} {}'.format(self._remote, self._branch),
             error_msg='Could not fetch specified branch "{}" from remote "{}".'.format(self._branch, self._remote)
         )
 

--- a/test/unit/project_type/test_git.py
+++ b/test/unit/project_type/test_git.py
@@ -136,25 +136,6 @@ class TestGit(BaseUnitTestCase):
 
         self.assertEqual(expected_timing_directory, actual_timing_directory)
 
-    def test_fetch_project_when_existing_repo_is_shallow_deletes_repo(self):
-        self.os_path_isfile_mock.return_value = True
-        self.os_path_exists_mock.return_value = True
-        mock_fs = self.patch('app.project_type.git.fs')
-        mock_rmtree = self.patch('shutil.rmtree')
-
-        git = Git('url')
-        git._repo_directory = 'fake/repo_path'
-        git._execute_and_raise_on_failure = MagicMock()
-        git.execute_command_in_project = Mock(return_value=('', 0))
-
-        mock_fs.create_dir.call_count = 0  # only measure calls made in _fetch_project
-        mock_rmtree.call_count = 0
-
-        git._fetch_project()
-
-        mock_rmtree.assert_called_once_with('fake/repo_path')
-        mock_fs.create_dir.assert_called_once_with('fake/repo_path', Git.DIRECTORY_PERMISSIONS)
-
     @genty_dataset(
         failed_rev_parse=(1, True),
         successful_rev_parse=(0, False),
@@ -168,7 +149,7 @@ class TestGit(BaseUnitTestCase):
         git = Git(url='http://original-user-specified-url.test/repo-path/repo-name')
         git.fetch_project()
 
-        git_clone_call = call(AnyStringMatching('git clone'), start_new_session=ANY,
+        git_clone_call = call(AnyStringMatching('git clone --depth=1'), start_new_session=ANY,
                               stdout=ANY, stderr=ANY, cwd=ANY, shell=ANY)
         if expect_git_clone_call:
             self.assertIn(git_clone_call, mock_popen.call_args_list, 'If "git rev-parse" returns a failing exit code, '


### PR DESCRIPTION
This change is necessary in order to improve CR performance, as well as to reduce the disk footprint of our VM images.

This should be backwards compatible for masters/slaves that already have non-shallow clones.