### PR TITLE
Add functional test for slave reconnection issue

### DIFF
--- a/app/master/cluster_master.py
+++ b/app/master/cluster_master.py
@@ -120,23 +120,23 @@ class ClusterMaster(ClusterService):
         # If a slave had previously been connected, and is now being reconnected, the cleanest way to resolve this
         # bookkeeping is for the master to forget about the previous slave instance and start with a fresh instance.
         if slave_url in self._all_slaves_by_url:
-            self._logger.warning('Slave on {} requested to connect to master, even though previously connected. ' +
-                                 'Removing existing slave instance from the master\'s bookkeeping.', slave_url)
             old_slave = self._all_slaves_by_url.get(slave_url)
+            self._logger.warning('Slave requested to connect to master, even though previously connected as {}. ' +
+                                 'Removing existing slave instance from the master\'s bookkeeping.', old_slave)
 
             # If a slave has requested to reconnect, we have to assume that whatever build the dead slave was
             # working on no longer has valid results.
             if old_slave.current_build_id is not None:
-                self._logger.info('{} has build [{}] running on it. Attempting to cancel build.', slave_url,
+                self._logger.info('{} has build [{}] running on it. Attempting to cancel build.', old_slave,
                                   old_slave.current_build_id)
                 try:
                     build = self.get_build(old_slave.current_build_id)
                     build.cancel()
                     self._logger.info('Cancelled build {} due to dead slave {}', old_slave.current_build_id,
-                                      slave_url)
+                                      old_slave)
                 except ItemNotFoundError:
                     self._logger.info('Failed to find build {} that was running on {}', old_slave.current_build_id,
-                                      slave_url)
+                                      old_slave)
 
         slave = Slave(slave_url, num_executors)
         self._all_slaves_by_url[slave_url] = slave

--- a/app/master/slave.py
+++ b/app/master/slave.py
@@ -29,6 +29,9 @@ class Slave(object):
         self._slave_api = UrlBuilder(slave_url, self.API_VERSION)
         self._logger = log.get_logger(__name__)
 
+    def __str__(self):
+        return '<slave #{} - {}>'.format(self.id, self.url)
+
     def api_representation(self):
         return {
             'url': self.url,

--- a/app/master/slave_allocator.py
+++ b/app/master/slave_allocator.py
@@ -49,8 +49,7 @@ class SlaveAllocator(object):
                 if build_scheduler.needs_more_slaves():
                     # Potential race condition here!  If the build completes after the if statement is checked,
                     # a slave will be allocated needlessly (and run slave.setup(), which can be significant work).
-                    self._logger.info('Allocating slave {} to build {}.',
-                                      claimed_slave.url, build_scheduler.build_id)
+                    self._logger.info('Allocating {} to build {}.', claimed_slave, build_scheduler.build_id)
                     build_scheduler.allocate_slave(claimed_slave)
                 else:
                     self.add_idle_slave(claimed_slave)

--- a/app/util/process_utils.py
+++ b/app/util/process_utils.py
@@ -3,7 +3,6 @@ import os
 import subprocess
 import time
 
-
 SIGINFO = 29  # signal.SIGINFO is not present in all Python distributions
 
 
@@ -25,12 +24,27 @@ def kill_gracefully(process, timeout=2):
         stdout, stderr = process.communicate(timeout=timeout)
 
     except subprocess.TimeoutExpired:
+        _, stdout, stderr = kill_hard(process)
+
+    return process.returncode, stdout, stderr
+
+
+def kill_hard(process):
+    """
+    Kill the specified process immediately using SIGKILL.
+
+    :param process: The process to terminate or kill
+    :type process: subprocess.Popen
+    :return: The exit code, stdout, and stderr of the process
+    :rtype: (int, str, str)
+    """
+    with suppress(ProcessLookupError):
         if not is_windows():
             process.send_signal(SIGINFO)  # this assumes a debug handler has been registered for SIGINFO
             time.sleep(1)  # give the logger a chance to write out debug info
         process.kill()
-        stdout, stderr = process.communicate()
 
+    stdout, stderr = process.communicate()
     return process.returncode, stdout, stderr
 
 

--- a/test/functional/test_cluster_basic.py
+++ b/test/functional/test_cluster_basic.py
@@ -33,23 +33,7 @@ class TestClusterBasic(BaseFunctionalTestCase):
         master.block_until_build_finished(build_id, timeout=30)
         slave.block_until_idle(timeout=20)  # ensure slave teardown has finished before making assertions
 
-        if test_job_config.expected_to_fail:
-            self.assert_build_has_failure_status(build_id=build_id)
-        else:
-            self.assert_build_has_successful_status(build_id=build_id)
-
-        self.assert_build_status_contains_expected_data(
-            build_id=build_id,
-            expected_data={
-                'num_atoms': test_job_config.expected_num_atoms,
-                'num_subjobs': test_job_config.expected_num_atoms})
-        self.assert_build_artifact_contents_match_expected(
-            master_api=master._api,
-            build_id=build_id,
-            expected_build_artifact_contents=test_job_config.expected_artifact_contents
-        )
-        self.assert_directory_contents_match_expected(
-            dir_path=project_dir.name, expected_dir_contents=test_job_config.expected_project_dir_contents)
+        self._assert_build_completed_as_expected(build_id, test_job_config, project_dir)
 
     # TODO: unskip the test when we've changed the default value of `get_project_from_master` to False
     @skip('Skipping for now since this fails on Travis due to the slave being unable to ssh into the master.')
@@ -82,3 +66,55 @@ class TestClusterBasic(BaseFunctionalTestCase):
             build_id=build_id, expected_data={'num_atoms': 10, 'num_subjobs': 10})
         self.assert_build_artifact_contents_match_expected(
             build_id=build_id, expected_build_artifact_contents=expected_artifact_contents)
+
+    @skip('This test currently fails due to https://github.com/box/ClusterRunner/issues/296.')
+    def test_slave_reconnection_does_not_take_down_master(self):
+        test_config = JOB_WITH_SETUP_AND_TEARDOWN
+        job_config = yaml.safe_load(test_config.config[os.name])['JobWithSetupAndTeardown']
+        master = self.cluster.start_master()
+
+        # Start a slave, hard kill it, then reconnect it.
+        self.cluster.start_slave(num_executors_per_slave=5, start_port=43001)
+        self.cluster.kill_slaves(kill_gracefully=False)
+
+        # Make sure the slave restarts with the same port.
+        slave = self.cluster.start_slave(num_executors_per_slave=5, start_port=43001)
+
+        # Start two builds.
+        project_dir = tempfile.TemporaryDirectory()
+        build_1 = master.post_new_build({
+            'type': 'directory',
+            'config': job_config,
+            'project_directory': project_dir.name,
+        })
+        build_2 = master.post_new_build({
+            'type': 'directory',
+            'config': job_config,
+            'project_directory': project_dir.name,
+        })
+
+        master.block_until_build_finished(build_1['build_id'], timeout=30)
+        master.block_until_build_finished(build_2['build_id'], timeout=30)
+        slave.block_until_idle(timeout=20)  # ensure slave teardown has finished before making assertions
+
+        self._assert_build_completed_as_expected(build_1['build_id'], test_config, project_dir)
+        self._assert_build_completed_as_expected(build_2['build_id'], test_config, project_dir)
+
+    def _assert_build_completed_as_expected(self, build_id, test_job_config, project_dir):
+        if test_job_config.expected_to_fail:
+            self.assert_build_has_failure_status(build_id=build_id)
+        else:
+            self.assert_build_has_successful_status(build_id=build_id)
+
+        self.assert_build_status_contains_expected_data(
+            build_id=build_id,
+            expected_data={
+                'num_atoms': test_job_config.expected_num_atoms,
+                'num_subjobs': test_job_config.expected_num_atoms})
+        self.assert_build_artifact_contents_match_expected(
+            master_api=self.cluster.master_api_client._api,  # todo: Don't use private _api. Add functionality to api_client instead.
+            build_id=build_id,
+            expected_build_artifact_contents=test_job_config.expected_artifact_contents
+        )
+        self.assert_directory_contents_match_expected(
+            dir_path=project_dir.name, expected_dir_contents=test_job_config.expected_project_dir_contents)


### PR DESCRIPTION
The added test in this commit is marked skipped for now due to #296
but will be unskipped in an upcoming commit when that issue is
fixed.

The functional test ensures a slave can die ungracefully and after
that host reconnects that everything will still work as expected.