### PR TITLE
Verify slave session id on is_alive check

### DIFF
--- a/app/util/session_id.py
+++ b/app/util/session_id.py
@@ -2,7 +2,9 @@ import uuid
 
 
 class SessionId(object):
+    EXPECTED_SESSION_HEADER_KEY = 'Expected-Session-Id'
     SESSION_HEADER_KEY = 'Session-Id'
+
     _session_id = None
 
     @classmethod

--- a/app/web_framework/cluster_base_handler.py
+++ b/app/web_framework/cluster_base_handler.py
@@ -91,7 +91,10 @@ class ClusterBaseAPIHandler(ClusterBaseHandler):
         the current instance's session id, then the requester is asking for a resource that has expired and
         no longer exists.
         """
-        session_id = self.request.headers.get(SessionId.SESSION_HEADER_KEY)
+        # An expected session header in a *request* should be declared using the "Expected-Session-Id" header
+        # but for legacy support an expected header can also be specified with the "Session-Id" header.
+        session_id = self.request.headers.get(SessionId.SESSION_HEADER_KEY) \
+            or self.request.headers.get(SessionId.EXPECTED_SESSION_HEADER_KEY)
 
         if session_id is not None and session_id != SessionId.get():
             raise PreconditionFailedError('Specified session id: {} has expired and is invalid.'.format(session_id))

--- a/test/functional/test_cluster_basic.py
+++ b/test/functional/test_cluster_basic.py
@@ -67,7 +67,6 @@ class TestClusterBasic(BaseFunctionalTestCase):
         self.assert_build_artifact_contents_match_expected(
             build_id=build_id, expected_build_artifact_contents=expected_artifact_contents)
 
-    @skip('This test currently fails due to https://github.com/box/ClusterRunner/issues/296.')
     def test_slave_reconnection_does_not_take_down_master(self):
         test_config = JOB_WITH_SETUP_AND_TEARDOWN
         job_config = yaml.safe_load(test_config.config[os.name])['JobWithSetupAndTeardown']

--- a/test/unit/master/test_slave.py
+++ b/test/unit/master/test_slave.py
@@ -6,6 +6,7 @@ from app.master.build_request import BuildRequest
 from app.master.slave import DeadSlaveError, SlaveMarkedForShutdownError, Slave
 from app.master.subjob import Subjob
 from app.util.secret import Secret
+from app.util.session_id import SessionId
 from test.framework.base_unit_test_case import BaseUnitTestCase
 
 
@@ -118,6 +119,17 @@ class TestSlave(BaseUnitTestCase):
         is_slave_alive = slave.is_alive(use_cached=False)
 
         self.assertTrue(is_slave_alive)
+
+    def test_is_alive_makes_correct_network_call_to_slave(self):
+        slave = self._create_slave(
+            slave_url='fake.slave.gov:43001',
+            slave_session_id='abc-123')
+
+        slave.is_alive(use_cached=False)
+
+        self.mock_network.get.assert_called_once_with(
+            'http://fake.slave.gov:43001/v1',
+            headers={SessionId.EXPECTED_SESSION_HEADER_KEY: 'abc-123'})
 
     def test_mark_as_idle_raises_when_executors_are_in_use(self):
         slave = self._create_slave()


### PR DESCRIPTION
Previously when the master checked if a slave is alive, it only
checked if the slave service is responsive at that url. This change
makes the master also verify that the slave service that responds at
that url still has the same session id that the slave reported when
it connected to the master.

This will cause the `slave.is_alive()` check on the master to start
returning false if the slave responds but has the wrong session id.
Previously this would return true.

This is done by setting a header in the master's request to the
slave that includes the expected session id. If the slave sees this
and it does not match its current session id, it will return a 412
and the master will consider the slave with the old session id to be
offline.

This fixes #296. Now when the slave allocator does the `is_alive()`
call before allocating a slave to a build, it will correctly detect
when a slave's session id has changed and should be considered
offline.