### PR TITLE
Move _builds_waiting_for_slaves queue to BuildSchedulerPool.

### DIFF
--- a/app/master/build_scheduler.py
+++ b/app/master/build_scheduler.py
@@ -63,10 +63,6 @@ class BuildScheduler(object):
 
         :type slave: Slave
         """
-        if not self._slaves_allocated:
-            # If this is the first slave to be allocated, update the build state.
-            self._build.mark_started()
-
         self._slaves_allocated.append(slave)
         slave.setup(self._build, executor_start_index=self._num_executors_allocated)
         self._num_executors_allocated += min(slave.num_executors, self._max_executors_per_slave)
@@ -101,18 +97,23 @@ class BuildScheduler(object):
             # this method, finds the subjob queue empty, and is torn down.  If that was the last 'living' slave, the
             # build would be stuck.
             with self._subjob_assignment_lock:
+                is_first_subjob = False
+                if self._build._unstarted_subjobs.qsize() == len(self._build.all_subjobs()):
+                    is_first_subjob = True
                 subjob = self._build._unstarted_subjobs.get(block=False)
                 self._logger.debug('Sending subjob {} (build {}) to slave {}.',
                                    subjob.subjob_id(), subjob.build_id(), slave.url)
                 try:
                     slave.start_subjob(subjob)
                     subjob.mark_in_progress(slave)
-
                 except SlaveMarkedForShutdownError:
                     self._build._unstarted_subjobs.put(subjob)  # todo: This changes subjob execution order. (Issue #226)
                     # An executor is currently allocated for this subjob in begin_subjob_executions_on_slave.
                     # Since the slave has been marked for shutdown, we need to free the executor.
                     self._free_slave_executor(slave)
+                else:
+                    if is_first_subjob:
+                        self._build.mark_started()
 
         except Empty:
             self._free_slave_executor(slave)

--- a/app/master/build_scheduler_pool.py
+++ b/app/master/build_scheduler_pool.py
@@ -1,3 +1,4 @@
+from queue import Queue
 from threading import Lock
 
 from app.master.build_scheduler import BuildScheduler
@@ -12,6 +13,7 @@ class BuildSchedulerPool(object):
     def __init__(self):
         self._schedulers_by_build_id = {}
         self._scheduler_creation_lock = Lock()
+        self._builds_waiting_for_slaves = Queue()
 
     def get(self, build):
         """
@@ -26,3 +28,21 @@ class BuildSchedulerPool(object):
                 self._schedulers_by_build_id[build.build_id()] = scheduler
 
         return scheduler
+
+    def next_prepared_build_scheduler(self):
+        """
+        Get the scheduler for the next build that has successfully completed build preparation.
+
+        This is a blocking call--if there are no more builds that have completed build preparation and this
+        method gets invoked, the execution will hang until the next build has completed build preparation.
+
+        :rtype: BuildScheduler
+        """
+        build = self._builds_waiting_for_slaves.get()
+        return self.get(build)
+
+    def add_build_waiting_for_slaves(self, build):
+        """
+        :type build: app.master.build.Build
+        """
+        self._builds_waiting_for_slaves.put(build)

--- a/app/master/cluster_master.py
+++ b/app/master/cluster_master.py
@@ -30,7 +30,7 @@ class ClusterMaster(ClusterService):
         self._scheduler_pool = BuildSchedulerPool()
         self._build_request_handler = BuildRequestHandler(self._scheduler_pool)
         self._build_request_handler.start()
-        self._slave_allocator = SlaveAllocator(self._build_request_handler)
+        self._slave_allocator = SlaveAllocator(self._scheduler_pool)
         self._slave_allocator.start()
 
         # Asynchronously delete (but immediately rename) all old builds when master starts.

--- a/app/master/slave_allocator.py
+++ b/app/master/slave_allocator.py
@@ -10,12 +10,12 @@ class SlaveAllocator(object):
     The SlaveAllocator class is responsible for allocating slaves to prepared builds.
     """
 
-    def __init__(self, build_request_handler):
+    def __init__(self, scheduler_pool):
         """
-        :type build_request_handler: BuildRequestHandler
+        :type scheduler_pool: app.master.build_scheduler_pool.BuildSchedulerPool
         """
         self._logger = get_logger(__name__)
-        self._build_request_handler = build_request_handler
+        self._scheduler_pool = scheduler_pool
         self._idle_slaves = OrderedSetQueue()
         self._allocation_thread = SafeThread(
             target=self._slave_allocation_loop, name='SlaveAllocationLoop', daemon=True)
@@ -36,7 +36,7 @@ class SlaveAllocator(object):
         """
         while True:
             # This is a blocking call that will block until there is a prepared build.
-            build_scheduler = self._build_request_handler.next_prepared_build_scheduler()
+            build_scheduler = self._scheduler_pool.next_prepared_build_scheduler()
 
             while build_scheduler.needs_more_slaves():
                 claimed_slave = self._idle_slaves.get()


### PR DESCRIPTION
This is part 1 of a two-part fix to handle error'ed build state from https://github.com/box/ClusterRunner/issues/313 .

This commit should be a NO-OP and have CR behave identically.