### PR TITLE
Allocating, de-allocating, and then re-allocating slaves should work.

### DIFF
--- a/app/master/build_scheduler.py
+++ b/app/master/build_scheduler.py
@@ -99,9 +99,7 @@ class BuildScheduler(object):
             # this method, finds the subjob queue empty, and is torn down.  If that was the last 'living' slave, the
             # build would be stuck.
             with self._subjob_assignment_lock:
-                is_first_subjob = False
-                if self._build._unstarted_subjobs.qsize() == len(self._build.all_subjobs()):
-                    is_first_subjob = True
+                is_first_subjob = (self._build._unstarted_subjobs.qsize() == len(self._build.all_subjobs()))
                 subjob = self._build._unstarted_subjobs.get(block=False)
                 self._logger.debug('Sending subjob {} (build {}) to slave {}.',
                                    subjob.subjob_id(), subjob.build_id(), slave.url)

--- a/app/master/cluster_master.py
+++ b/app/master/cluster_master.py
@@ -30,7 +30,7 @@ class ClusterMaster(ClusterService):
         self._scheduler_pool = BuildSchedulerPool()
         self._build_request_handler = BuildRequestHandler(self._scheduler_pool)
         self._build_request_handler.start()
-        self._slave_allocator = SlaveAllocator(self._build_request_handler)
+        self._slave_allocator = SlaveAllocator(self._scheduler_pool)
         self._slave_allocator.start()
 
         # Asynchronously delete (but immediately rename) all old builds when master starts.

--- a/app/master/slave_allocator.py
+++ b/app/master/slave_allocator.py
@@ -10,12 +10,12 @@ class SlaveAllocator(object):
     The SlaveAllocator class is responsible for allocating slaves to prepared builds.
     """
 
-    def __init__(self, build_request_handler):
+    def __init__(self, scheduler_pool):
         """
-        :type build_request_handler: BuildRequestHandler
+        :type scheduler_pool: app.master.build_scheduler_pool.BuildSchedulerPool
         """
         self._logger = get_logger(__name__)
-        self._build_request_handler = build_request_handler
+        self._scheduler_pool = scheduler_pool
         self._idle_slaves = OrderedSetQueue()
         self._allocation_thread = SafeThread(
             target=self._slave_allocation_loop, name='SlaveAllocationLoop', daemon=True)
@@ -36,7 +36,7 @@ class SlaveAllocator(object):
         """
         while True:
             # This is a blocking call that will block until there is a prepared build.
-            build_scheduler = self._build_request_handler.next_prepared_build_scheduler()
+            build_scheduler = self._scheduler_pool.next_prepared_build_scheduler()
 
             while build_scheduler.needs_more_slaves():
                 claimed_slave = self._idle_slaves.get()

--- a/test/functional/job_configs.py
+++ b/test/functional/job_configs.py
@@ -151,3 +151,34 @@ JobWithSetupAndTeardown:
         File('subjob_file_3.txt', contents='setup.\nsubjob 3.\nteardown.\n'),
     ],
 )
+
+# This is a very basic job where each atom just creates a simple text file.
+JOB_WITH_SLEEPS = FunctionalTestJobConfig(
+    config={
+        'posix': """
+BasicSleepingJob:
+    commands:
+        - sleep 1
+    atomizers:
+        - TOKEN: seq 0 4 | xargs -I {} echo "This is atom {}"
+
+""",
+        'nt': """
+BasicSleepingJob:
+    commands:
+        - timeout 1 > NUL
+    atomizers:
+        - TOKEN: FOR /l %n in (0,1,4) DO @echo This is atom %n
+""",
+    },
+    expected_to_fail=False,
+    expected_num_subjobs=5,
+    expected_num_atoms=5,
+    expected_artifact_contents=[
+        Directory('artifact_0_0', DEFAULT_ATOM_FILES + [File('result.txt', contents='This is atom 0\n')]),
+        Directory('artifact_1_0', DEFAULT_ATOM_FILES + [File('result.txt', contents='This is atom 1\n')]),
+        Directory('artifact_2_0', DEFAULT_ATOM_FILES + [File('result.txt', contents='This is atom 2\n')]),
+        Directory('artifact_3_0', DEFAULT_ATOM_FILES + [File('result.txt', contents='This is atom 3\n')]),
+        Directory('artifact_4_0', DEFAULT_ATOM_FILES + [File('result.txt', contents='This is atom 4\n')]),
+    ],
+)

--- a/test/functional/job_configs.py
+++ b/test/functional/job_configs.py
@@ -152,7 +152,7 @@ JobWithSetupAndTeardown:
     ],
 )
 
-# This is a very basic job where each atom just creates a simple text file.
+# This is a very basic job where each atom just sleeps for 1 second.
 JOB_WITH_SLEEPS = FunctionalTestJobConfig(
     config={
         'posix': """
@@ -174,11 +174,4 @@ BasicSleepingJob:
     expected_to_fail=False,
     expected_num_subjobs=5,
     expected_num_atoms=5,
-    expected_artifact_contents=[
-        Directory('artifact_0_0', DEFAULT_ATOM_FILES + [File('result.txt', contents='This is atom 0\n')]),
-        Directory('artifact_1_0', DEFAULT_ATOM_FILES + [File('result.txt', contents='This is atom 1\n')]),
-        Directory('artifact_2_0', DEFAULT_ATOM_FILES + [File('result.txt', contents='This is atom 2\n')]),
-        Directory('artifact_3_0', DEFAULT_ATOM_FILES + [File('result.txt', contents='This is atom 3\n')]),
-        Directory('artifact_4_0', DEFAULT_ATOM_FILES + [File('result.txt', contents='This is atom 4\n')]),
-    ],
 )

--- a/test/functional/master/test_deallocation_and_allocation_of_slaves_mid_build.py
+++ b/test/functional/master/test_deallocation_and_allocation_of_slaves_mid_build.py
@@ -1,0 +1,30 @@
+import os
+import tempfile
+import yaml
+
+from test.framework.functional.base_functional_test_case import BaseFunctionalTestCase
+from test.functional.job_configs import JOB_WITH_SLEEPS
+
+
+class TestDeallocationAndAllocationOfSlavesMidBuild(BaseFunctionalTestCase):
+    def test_build_completes_after_allocating_deallocating_and_reallocating_slaves_to_build(self):
+        master = self.cluster.start_master()
+        # Only one slave, with one executor. This means that the slave should be able to
+        # theoretically finish the build in 5 seconds, as this job definition has 5 atoms,
+        # with each sleeping for 1 second.
+        self.cluster.start_slaves(1, num_executors_per_slave=1, start_port=43001)
+        project_dir = tempfile.TemporaryDirectory()
+        build_resp = master.post_new_build({
+            'type': 'directory',
+            'config': yaml.safe_load(JOB_WITH_SLEEPS.config[os.name])['BasicSleepingJob'],
+            'project_directory': project_dir.name,
+        })
+        build_id = build_resp['build_id']
+        master.block_until_build_started(build_id, timeout=10)
+        master.graceful_shutdown_slaves_by_id([1])
+        self.cluster.block_until_n_slaves_dead(num_slaves=1, timeout=10)
+        self.cluster.kill_slaves(kill_gracefully=False)
+        self.assert_build_status_contains_expected_data(build_id, {'status': 'BUILDING'})
+        self.cluster.start_slaves(1, num_executors_per_slave=1, start_port=43001)
+        master.block_until_build_finished(build_id, timeout=10)
+        self.assert_build_has_successful_status(build_id)

--- a/test/unit/master/test_build.py
+++ b/test/unit/master/test_build.py
@@ -110,12 +110,11 @@ class TestBuild(BaseUnitTestCase):
         self.assertEqual(build._status(), BuildStatus.PREPARED,
                          'Build status should be PREPARED after build has been prepared.')
 
-    def test_build_status_returns_building_after_first_subjob_has_been_executed(self):
+    def test_build_status_returns_building_after_setup_has_started(self):
         mock_slave = self._create_mock_slave()
         build = self._create_test_build(BuildStatus.PREPARED)
         scheduler = self.scheduler_pool.get(build)
         scheduler.allocate_slave(mock_slave)
-        scheduler.execute_next_subjob_or_free_executor(mock_slave)
 
         self.assertEqual(build._status(), BuildStatus.BUILDING,
                          'Build status should be BUILDING after setup has started on slaves.')
@@ -359,22 +358,22 @@ class TestBuild(BaseUnitTestCase):
 
         self.mock_util.fs.create_dir.assert_called_once_with(build._build_results_dir())
 
-    def test_execute_next_subjob_or_free_executor_sets_building_timestamp_only_on_first_execution(self):
+    def test_allocating_slave_to_build_sets_building_timestamp_only_on_first_slave_allocation(self):
         mock_slave1 = self._create_mock_slave()
+        mock_slave2 = self._create_mock_slave()
         build = self._create_test_build(BuildStatus.PREPARED)
         scheduler = self.scheduler_pool.get(build)
-        scheduler.allocate_slave(slave=mock_slave1)
 
         self.assertIsNone(self._get_build_state_timestamp(build, BuildState.BUILDING),
-                          '"building" timestamp should not be set until first subjob is started.')
+                          '"building" timestamp should not be set until slave allocated.')
 
-        scheduler.execute_next_subjob_or_free_executor(mock_slave1)
+        scheduler.allocate_slave(slave=mock_slave1)
         building_timestamp1 = self._get_build_state_timestamp(build, BuildState.BUILDING)
-        scheduler.execute_next_subjob_or_free_executor(mock_slave1)
+        scheduler.allocate_slave(slave=mock_slave2)
         building_timestamp2 = self._get_build_state_timestamp(build, BuildState.BUILDING)
-        self.assertIsNotNone(building_timestamp1, '"building" timestamp should be set after first subjob is started.')
+        self.assertIsNotNone(building_timestamp1, '"building" timestamp should be set after first slave allocated.')
         self.assertEqual(building_timestamp1, building_timestamp2,
-                         '"building" timestamp should not change upon further subjob execution.')
+                         '"building" timestamp should not change upon further slave allocation.')
 
     def test_finishing_build_sets_finished_timestamp(self):
         build = self._create_test_build(BuildStatus.BUILDING)

--- a/test/unit/master/test_build.py
+++ b/test/unit/master/test_build.py
@@ -366,7 +366,7 @@ class TestBuild(BaseUnitTestCase):
         scheduler.allocate_slave(slave=mock_slave1)
 
         self.assertIsNone(self._get_build_state_timestamp(build, BuildState.BUILDING),
-                          '"building" timestamp should not be set until slave allocated.')
+                          '"building" timestamp should not be set until first subjob is started.')
 
         scheduler.execute_next_subjob_or_free_executor(mock_slave1)
         building_timestamp1 = self._get_build_state_timestamp(build, BuildState.BUILDING)


### PR DESCRIPTION
This PR should fix https://github.com/box/ClusterRunner/issues/313

Currently, when slaves are added, removed, and added again to a build, the build fails to complete successfully.