### PR TITLE
Fix broken functional tests on windows

### DIFF
--- a/test/functional/master/test_endpoints.py
+++ b/test/functional/master/test_endpoints.py
@@ -1,4 +1,6 @@
 import os
+import tempfile
+
 import yaml
 
 from test.framework.functional.base_functional_test_case import BaseFunctionalTestCase
@@ -7,12 +9,16 @@ from test.functional.job_configs import BASIC_JOB
 
 class TestMasterEndpoints(BaseFunctionalTestCase):
 
+    def setUp(self):
+        super().setUp()
+        self._project_dir = tempfile.TemporaryDirectory()
+
     def _start_master_only_and_post_a_new_job(self):
         master = self.cluster.start_master()
         build_resp = master.post_new_build({
             'type': 'directory',
             'config': yaml.safe_load(BASIC_JOB.config[os.name])['BasicJob'],
-            'project_directory': '/tmp',
+            'project_directory': self._project_dir.name,
             })
         build_id = build_resp['build_id']
         return master, build_id


### PR DESCRIPTION
Something must have changed on the Appveyor side since this code
hasn't been touched recently. The issue was that a functional test
was referring to "/tmp" which is not valid on Windows. I'm surprised
this worked on Windows in the first place.