### PR TITLE
Prevent immortal connection pools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ test: test-unit test-functional
 
 init:
 	$(call print_msg, Installing requirements... )
-	pip install -r requirements.txt
+	pip install --upgrade -r requirements.txt
 
 pylint:
 	$(call print_msg, Running pylint... )

--- a/app/master/slave.py
+++ b/app/master/slave.py
@@ -208,6 +208,7 @@ class Slave(object):
         """
         self.set_is_alive(False)
         self.current_build_id = None
+        self._network.reset_session()  # Close any pooled connections for this slave.
 
     def _expected_session_header(self):
         """


### PR DESCRIPTION
The master keeps a connection pool for each connected slave. The
problem is that even when the slave disconnects/is taken offline
those pooled connections stay open. This isn't that bad unless
you're constantly connecting and disconnecting slaves.

At Box we constantly connect and disconnect slaves (recycling the
entire cluster once a night). Over several weeks the immortal
connection pools eventually cause the master process to hit a system
limit on the number of open file descriptors. :(

This change makes sure we clear the connection pool when a slave
disconnects.