### PR TITLE
Add Prometheus instrumentation

### DIFF
--- a/app/web_framework/cluster_base_handler.py
+++ b/app/web_framework/cluster_base_handler.py
@@ -120,6 +120,10 @@ class ClusterBaseAPIHandler(ClusterBaseHandler):
             response['child_routes'] = self.get_child_routes()
         super().write(response)
 
+    def write_text(self, response):
+        super().set_header('Content-Type', 'text/plain; charset=utf-8')
+        super().write(response)
+
     def _write_status(self, additional_response=None, success=True, status_code=200):
         status = self.SUCCESS_STATUS if success else self.FAILURE_STATUS
         response = {'status': status}

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ Logbook==0.7.0
 nose==1.3.4
 nosexcover==1.0.10
 pep8==1.5.7
+prometheus_client==0.0.19
 psutil==2.1.2
 pylint==1.5.1
 PyYAML==3.11


### PR DESCRIPTION
This change uses the Prometheus client SDK to add some instrumentation to the master. So far, only HTTP request latency is instrumented.

There is also a new endpoint at /v1/metrics which exposes the metrics in in Prometheus text exposition format. The metrics endpoint required a new method in ClusterBaseHandler so that a raw text string could be written.