### PR TITLE
Add timeout to all outgoing http requests

### DIFF
--- a/app/master/build.py
+++ b/app/master/build.py
@@ -256,6 +256,7 @@ class Build(object):
         # We use a local variable here which was set inside the _build_completion_lock to prevent a race condition
         if should_trigger_postbuild_tasks:
             self._logger.info("All results received for build {}!", self._build_id)
+            # todo: This should not be a SafeThread. https://github.com/box/ClusterRunner/issues/323
             SafeThread(target=self._perform_async_postbuild_tasks, name='PostBuild{}'.format(self._build_id)).start()
 
     def mark_started(self):

--- a/app/slave/cluster_slave.py
+++ b/app/slave/cluster_slave.py
@@ -252,7 +252,7 @@ class ClusterSlave(ClusterService):
         is_responsive = True
         try:
             self._network.get(self._master_api.url())
-        except requests.ConnectionError:
+        except (requests.ConnectionError, requests.Timeout):
             is_responsive = False
 
         return is_responsive

--- a/app/util/conf/base_config_loader.py
+++ b/app/util/conf/base_config_loader.py
@@ -76,6 +76,8 @@ class BaseConfigLoader(object):
         conf.set('master_port', '43000')
         conf.set('slaves', ['localhost'])
 
+        conf.set('default_http_timeout', 30)
+
         # Strict host key checking on git remote operations, disabled by default
         conf.set('git_strict_host_key_checking', False)
 
@@ -141,6 +143,7 @@ class BaseConfigLoader(object):
             'git_strict_host_key_checking',
             'cors_allowed_origins_regex',
             'get_project_from_master',
+            'default_http_timeout',
         ]
 
     def _load_section_from_config_file(self, config, config_filename, section):

--- a/app/util/conf/slave_config_loader.py
+++ b/app/util/conf/slave_config_loader.py
@@ -20,6 +20,10 @@ class SlaveConfigLoader(BaseConfigLoader):
         conf.set('master_hostname', 'localhost')
         conf.set('master_port', 43000)
         conf.set('shallow_clones', True)
+        # Use a longer timeout for slaves since we don't yet have request metrics on the slave side and since
+        # slaves are more likely to encounter long response times on the master due to the master being a
+        # centralized hub with a single-threaded server.
+        conf.set('default_http_timeout', 120)
 
     def configure_postload(self, conf):
         """

--- a/test/framework/functional/base_functional_test_case.py
+++ b/test/framework/functional/base_functional_test_case.py
@@ -1,12 +1,12 @@
 from contextlib import suppress
 import http.client
 import os
-from os import path
-import shutil
 import tempfile
 from unittest import TestCase
 
 from app.util import fs, log
+from app.util.conf.base_config_loader import BaseConfigLoader
+from app.util.conf.configuration import Configuration
 from app.util.process_utils import is_windows
 from app.util.network import Network
 from app.util.secret import Secret
@@ -26,10 +26,18 @@ class BaseFunctionalTestCase(TestCase):
         # Configure logging to go to stdout. This makes debugging easier by allowing us to see logs for failed tests.
         log.configure_logging('DEBUG')
 
+        self._reset_config()
         Secret.set('testsecret')
 
         self.cluster = FunctionalTestCluster(verbose=self._get_test_verbosity())
         self._network = Network()
+
+    def _reset_config(self):
+        Configuration.reset_singleton()
+        config = Configuration.singleton()
+        conf_loader = BaseConfigLoader()
+        conf_loader.configure_defaults(config)
+        conf_loader.configure_postload(config)
 
     def tearDown(self):
         # Give the cluster a bit of extra time to finish working (before forcefully killing it and failing the test)

--- a/test/functional/master/test_http_timeout.py
+++ b/test/functional/master/test_http_timeout.py
@@ -1,0 +1,117 @@
+from collections import deque
+import os
+import tempfile
+from threading import Event, Thread
+import yaml
+
+from genty import genty, genty_dataset
+from tornado import httpserver, ioloop, web
+
+from test.framework.functional.base_functional_test_case import BaseFunctionalTestCase
+from test.functional.job_configs import JOB_WITH_SETUP_AND_TEARDOWN
+
+
+@genty
+class TestHttpTimeout(BaseFunctionalTestCase):
+
+    UNRESPONSIVE_SLAVE_PORT = 43001
+    NORMAL_SLAVE_PORT = 43002
+
+    @genty_dataset(
+        on_first_request=([],),
+        on_second_request=(['{"slave": {"is_alive": true}}'],),
+    )
+    def test_unresponsive_slave_does_not_hang_master(self, responses):
+        # Start the master and an unresponsive slave.
+        master = self.cluster.start_master(default_http_timeout=1)
+        unresponsive_slave = UnresponsiveServer().start(
+            port=self.UNRESPONSIVE_SLAVE_PORT,
+            responses=deque(responses))
+        unresponsive_slave_id = master.connect_slave(
+            'http://localhost:{}'.format(self.UNRESPONSIVE_SLAVE_PORT),
+            num_executors=1)
+
+        self.addCleanup(unresponsive_slave.stop)
+
+        # Start a build which will be cause an attempt to allocate the unresponsive slave.
+        project_dir = tempfile.TemporaryDirectory()
+        build_resp = master.post_new_build({
+            'type': 'directory',
+            'config': yaml.safe_load(JOB_WITH_SETUP_AND_TEARDOWN.config[os.name])['JobWithSetupAndTeardown'],
+            'project_directory': project_dir.name,
+        })
+        build_id = build_resp['build_id']
+
+        self.assertTrue(
+            master.block_until_slave_offline(unresponsive_slave_id, timeout=10),
+            'Unresponsive slave should be marked offline.')
+
+        # First slave should now be marked offline. Connect a real slave to finish the build.
+        self.cluster.start_slaves(num_slaves=1, start_port=self.NORMAL_SLAVE_PORT)
+        master.block_until_build_finished(build_id, timeout=10)
+        self.assert_build_has_successful_status(build_id)
+
+
+class UnresponsiveServer:
+    """
+    Server to emulate an unresponsive slave. This can optionally can return a sequence of
+    specified responses before finally becoming unresponsive.
+    """
+    def __init__(self):
+        self._server_started_event = Event()
+        self._stop_hanging_event = Event()
+        self._server_thread = None
+        self._server = None
+        self._ioloop = None
+
+    def start(self, port: int, responses: deque=None) -> 'UnresponsiveServer':
+        """
+        Start the server on a separate thread. Block until the server is started.
+        :param port: Port to serve on
+        :param responses: A list of responses to return before becoming unresponsive
+        """
+        self._server_thread = Thread(
+            target=self._run_server,
+            name='UnresponsiveServer',
+            kwargs={'port': port, 'responses': responses},
+        )
+        self._server_thread.start()
+        self._server_started_event.wait()
+        return self
+
+    def _run_server(self, port: int, responses: deque=None):
+        self._server = httpserver.HTTPServer(web.Application([
+            (r'.*', UnresponsiveHandler, {
+                'stop_hanging_event': self._stop_hanging_event,
+                'responses': responses,
+            })
+        ]))
+        self._server.listen(port)
+        self._ioloop = ioloop.IOLoop.current()
+        self._ioloop.add_callback(self._server_started_event.set)
+        self._ioloop.start()  # blocks until ioloop is stopped
+
+    def stop(self):
+        """Stop the running server. Block until the server is stopped."""
+        if self._server_thread:
+            self._server.stop()
+            self._ioloop.add_callback(self._ioloop.stop)
+            self._stop_hanging_event.set()  # Unblock any currently hanging request.
+            self._server_thread.join()  # Make sure server dies before returning.
+
+
+class UnresponsiveHandler(web.RequestHandler):
+    def initialize(self, stop_hanging_event: Event=None, responses: deque=None):
+        self._responses = responses
+        self._stop_hanging_event = stop_hanging_event
+
+    def _handle_request(self):
+        if self._responses:
+            self.write(self._responses.popleft())
+        else:
+            self._stop_hanging_event.wait(300)  # Block request without responding.
+
+    # Use same handler for all http methods.
+    get = _handle_request
+    post = _handle_request
+    put = _handle_request


### PR DESCRIPTION
Currently if a slave becomes unresponsive the master service will
freeze up for a long time (or forever). The slave allocation loop
will hang trying to contact a slave and no builds will be able to
start.

This adds a timeout to all requests between the master and slaves
and corresponding error handling. I made the timeout on
slave->master calls longer because we don't currently have great
metrics and have had issues with request load on the master in the
past (which we should improve separately).