### PR TITLE
Ignore zipfile artifact creation failures

### DIFF
--- a/test/unit/master/test_build.py
+++ b/test/unit/master/test_build.py
@@ -447,6 +447,7 @@ class TestBuild(BaseUnitTestCase):
 
     def test_exception_during_postbuild_tasks_fails_build(self):
         self.mock_util.fs.zip_directory.side_effect = FileNotFoundError('Where my files at?')
+        self.mock_util.fs.tar_directory.side_effect = FileNotFoundError('Where my files at?')
 
         build = self._create_test_build(BuildStatus.FINISHED)
 


### PR DESCRIPTION
We've seen an issue (#339) on our ClusterRunner production instance that will cause zip creation to fail with a FileNotFoundError. Since we're not yet depending on zip files, this just logs and ignores any failures that occur.

This also moves zip creation to occur after tar.gz creation. Hopefully we'll be able to use the successfully created tar.gz artifact to debug issues with creating the zip artifact.