### PR TITLE
Enable autoversioning to output correct version

### DIFF
--- a/app/util/package_version.py
+++ b/app/util/package_version.py
@@ -1,1 +1,0 @@
-version = '0.0.0'  # This should not be set to a real version. This file is modified during freeze.


### PR DESCRIPTION
This is an enhancement to enable rpm building with auto-generated version. Addresses #348.
1. Now `autoversioning.py` can be used by Makefile to generate a version string for building ClusterRunner rpm.
2. ClusterRunner executable
    1. First looks for version in hardcoded (generated while rpm building) `package_version.py` file.
    2. Else it calculates the version using git commit count (assuming its running within git repo).
    3. If 1 and 2 fails ClusterRunner will print '0.0.0' as default version.