### PR TITLE
Add mypy to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@
 configobj==5.0.6
 fysom==2.1.2
 Logbook==0.7.0
+mypy==0.511
 prometheus_client==0.0.19
 psutil==2.1.2
 PyYAML==3.11


### PR DESCRIPTION
Mypy includes `typing` which enables smarter type hints. It would
also be cool to eventually start running the mypy linter on PRs.