### PR TITLE
Add typing to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ PyYAML==3.11
 requests==2.3.0
 termcolor==1.1.0
 tornado==3.2.2
+typing==3.6.1


### PR DESCRIPTION
This enables smarter type hints in annotations. We should start
moving hints out of docstrings and into function annotations.

This is an alternative for #353.