### PR TITLE
Hide stderr in autoversioning

### DIFF
--- a/app/util/autoversioning.py
+++ b/app/util/autoversioning.py
@@ -172,6 +172,7 @@ def _execute_local_git_command(*args):
     command_output = subprocess.check_output(
         ['git'] + list(args),
         cwd=os.path.dirname(__file__),
+        stderr=subprocess.DEVNULL,
     )
     return command_output.decode()
 


### PR DESCRIPTION
If autoversioning-related git commands fail, the app just reports its version as 0.0.0. But currently the stderr from the failing git commands is not suppressed. This can be seen in TravisCI output as a bunch of scary "fatal: Needed a single revision" lines, but we should just hide those.