### PR TITLE
Generate repo url with scheme if netloc is empty

### DIFF
--- a/app/project_type/git.py
+++ b/app/project_type/git.py
@@ -41,7 +41,9 @@ class Git(ProjectType):
         url_folder_path_parts = url_full_path_parts[:-1]
         repo_directory = os.path.join(
             base_sys_path,
-            url_components.netloc.replace(':', ''),  # remove colons from netloc (e.g. turn example:8000 to example8000)
+            # Remove colons from netloc/scheme (e.g. turn example:8000 to example8000).
+            # If netloc is empty the url is malformed -- use scheme instead.
+            (url_components.netloc or url_components.scheme).replace(':', ''),
             *url_folder_path_parts
         )
         # remove '-'s as PHP Intl extension doesn't appear to work if the repo is in a directory with a dash in the path

--- a/app/project_type/git.py
+++ b/app/project_type/git.py
@@ -43,7 +43,7 @@ class Git(ProjectType):
         url_host_path_part = url_components.netloc or url_components.scheme
         repo_directory = os.path.join(
             base_sys_path,
-            url_host_path_part.replace(':', ''), # Remove colons (e.g. turn example:8000 to example8000).
+            url_host_path_part.replace(':', ''),  # Remove colons (e.g. turn example:8000 to example8000).
             *url_folder_path_parts
         )
         # remove '-'s as PHP Intl extension doesn't appear to work if the repo is in a directory with a dash in the path

--- a/app/project_type/git.py
+++ b/app/project_type/git.py
@@ -39,11 +39,11 @@ class Git(ProjectType):
         url_full_path_parts = url_components.path.split('/')
         repo_name = url_full_path_parts[-1].split('.')[0]
         url_folder_path_parts = url_full_path_parts[:-1]
+        # If netloc is empty the url is malformed -- use scheme instead.
+        url_host_path_part = url_components.netloc or url_components.scheme
         repo_directory = os.path.join(
             base_sys_path,
-            # Remove colons from netloc/scheme (e.g. turn example:8000 to example8000).
-            # If netloc is empty the url is malformed -- use scheme instead.
-            (url_components.netloc or url_components.scheme).replace(':', ''),
+            url_host_path_part.replace(':', ''), # Remove colons (e.g. turn example:8000 to example8000).
             *url_folder_path_parts
         )
         # remove '-'s as PHP Intl extension doesn't appear to work if the repo is in a directory with a dash in the path

--- a/test/unit/project_type/test_git.py
+++ b/test/unit/project_type/test_git.py
@@ -286,6 +286,31 @@ class TestGit(BaseUnitTestCase):
         project_type_popen_patch.side_effect = fake_popen_constructor
         return project_type_popen_patch
 
+    def test_get_repo_directory_with_no_netloc(self):
+        Configuration['repo_directory'] = join(expanduser('~'), '.clusterrunner', 'repos')
+        url = 'git.dev.box.net:Productivity/ClusterRunnerHealthCheck'
+
+        actual_repo_directory = Git.get_full_repo_directory(url)
+        expected_repo_directory = join(
+            Configuration['repo_directory'],
+            'git.dev.box.net',
+            'Productivity',
+            'ClusterRunnerHealthCheck',
+        )
+        self.assertEqual(expected_repo_directory, actual_repo_directory)
+
+    def test_get_repo_directory_with_netloc(self):
+        Configuration['repo_directory'] = join(expanduser('~'), '.clusterrunner', 'repos')
+        url = 'ssh://scm.dev.box.net:12345/awesome-project'
+
+        actual_repo_directory = Git.get_full_repo_directory(url)
+        expected_repo_directory = join(
+            Configuration['repo_directory'],
+            'scm.dev.box.net12345',
+            'awesomeproject',
+        )
+        self.assertEqual(expected_repo_directory, actual_repo_directory)
+
 
 class _FakePopenResult:
     def __init__(self, return_code=0, stdout='', stderr=''):

--- a/test/unit/project_type/test_git.py
+++ b/test/unit/project_type/test_git.py
@@ -79,20 +79,41 @@ class TestGit(BaseUnitTestCase):
             start_new_session=ANY,
         )
 
-    def test_get_full_repo_directory(self):
+    @genty_dataset(
+        regular_path=(
+            'http://scm.example.com/path/to/project', 
+             join(
+                'scm.example.com',
+                'path',
+                'to',
+                'project',
+            )
+        ),
+        with_netloc=(
+            'ssh://scm.dev.box.net:12345/awesome-project',
+            join(
+                'scm.dev.box.net12345',
+                'awesomeproject',
+            )
+        ),
+        no_netloc=(
+            'git.dev.box.net:Productivity/ClusterRunnerHealthCheck',
+            join(
+                'git.dev.box.net',
+                'Productivity',
+                'ClusterRunnerHealthCheck',
+            )
+        ),
+    )
+    def test_get_full_repo_directory(self, url, expected_repo_path_without_base):
         Configuration['repo_directory'] = join(expanduser('~'), '.clusterrunner', 'repos')
-        url = 'http://scm.example.com/path/to/project'
-
-        actual_repo_sys_path = Git.get_full_repo_directory(url)
-
-        expected_repo_sys_path = join(
-            Configuration['repo_directory'],
-            'scm.example.com',
-            'path',
-            'to',
-            'project',
+        expected_repo_path = join(
+            Configuration['repo_directory'], 
+            expected_repo_path_without_base
         )
-        self.assertEqual(expected_repo_sys_path, actual_repo_sys_path)
+
+        actual_repo_path = Git.get_full_repo_directory(url)
+        self.assertEqual(expected_repo_path, actual_repo_path)
 
     def test_get_timing_file_directory(self):
         Configuration['timings_directory'] = join(expanduser('~'), '.clusterrunner', 'timing')
@@ -285,31 +306,6 @@ class TestGit(BaseUnitTestCase):
 
         project_type_popen_patch.side_effect = fake_popen_constructor
         return project_type_popen_patch
-
-    def test_get_repo_directory_with_no_netloc(self):
-        Configuration['repo_directory'] = join(expanduser('~'), '.clusterrunner', 'repos')
-        url = 'git.dev.box.net:Productivity/ClusterRunnerHealthCheck'
-
-        actual_repo_directory = Git.get_full_repo_directory(url)
-        expected_repo_directory = join(
-            Configuration['repo_directory'],
-            'git.dev.box.net',
-            'Productivity',
-            'ClusterRunnerHealthCheck',
-        )
-        self.assertEqual(expected_repo_directory, actual_repo_directory)
-
-    def test_get_repo_directory_with_netloc(self):
-        Configuration['repo_directory'] = join(expanduser('~'), '.clusterrunner', 'repos')
-        url = 'ssh://scm.dev.box.net:12345/awesome-project'
-
-        actual_repo_directory = Git.get_full_repo_directory(url)
-        expected_repo_directory = join(
-            Configuration['repo_directory'],
-            'scm.dev.box.net12345',
-            'awesomeproject',
-        )
-        self.assertEqual(expected_repo_directory, actual_repo_directory)
 
 
 class _FakePopenResult:

--- a/test/unit/project_type/test_git.py
+++ b/test/unit/project_type/test_git.py
@@ -82,34 +82,22 @@ class TestGit(BaseUnitTestCase):
     @genty_dataset(
         regular_path=(
             'http://scm.example.com/path/to/project', 
-             join(
-                'scm.example.com',
-                'path',
-                'to',
-                'project',
-            )
+             join('scm.example.com', 'path', 'to', 'project')
         ),
         with_netloc=(
             'ssh://scm.dev.box.net:12345/awesome-project',
-            join(
-                'scm.dev.box.net12345',
-                'awesomeproject',
-            )
+            join('scm.dev.box.net12345', 'awesomeproject')
         ),
         no_netloc=(
             'git.dev.box.net:Productivity/ClusterRunnerHealthCheck',
-            join(
-                'git.dev.box.net',
-                'Productivity',
-                'ClusterRunnerHealthCheck',
-            )
+            join('git.dev.box.net', 'Productivity', 'ClusterRunnerHealthCheck')
         ),
     )
     def test_get_full_repo_directory(self, url, expected_repo_path_without_base):
         Configuration['repo_directory'] = join(expanduser('~'), '.clusterrunner', 'repos')
         expected_repo_path = join(
             Configuration['repo_directory'], 
-            expected_repo_path_without_base
+            expected_repo_path_without_base,
         )
 
         actual_repo_path = Git.get_full_repo_directory(url)


### PR DESCRIPTION
For certain urls, the `urlparse` function won't behave as expected, and the url's netloc field will be empty. In this case, we can just use the scheme field to mitigate ambiguitiy across hosts.

Resolves: #324