### PR TITLE
Fail functional tests if builds are slow

### DIFF
--- a/test/functional/master/test_console_output.py
+++ b/test/functional/master/test_console_output.py
@@ -22,7 +22,8 @@ class TestConsoleOutput(BaseFunctionalTestCase):
             'project_directory': self.project_dir.name,
         })
         build_id = build_resp['build_id']
-        master.block_until_build_finished(build_id, timeout=30)
+        self.assertTrue(master.block_until_build_finished(build_id, timeout=30),
+                        'The build should finish building within the timeout.')
         self.assert_build_has_successful_status(build_id)
 
         # Bring down the single slave and assert that console output for the build is still available.

--- a/test/functional/master/test_deallocation_and_allocation_of_slaves_mid_build.py
+++ b/test/functional/master/test_deallocation_and_allocation_of_slaves_mid_build.py
@@ -23,11 +23,13 @@ class TestDeallocationAndAllocationOfSlavesMidBuild(BaseFunctionalTestCase):
             'project_directory': project_dir.name,
         })
         build_id = build_resp['build_id']
-        master.block_until_build_started(build_id, timeout=10)
+        self.assertTrue(master.block_until_build_started(build_id, timeout=30),
+                        'The build should start building within the timeout.')
         master.graceful_shutdown_slaves_by_id([1])
         self.cluster.block_until_n_slaves_dead(num_slaves=1, timeout=10)
         self.cluster.kill_slaves(kill_gracefully=False)
         self.assert_build_status_contains_expected_data(build_id, {'status': 'BUILDING'})
         self.cluster.start_slaves(1, num_executors_per_slave=1, start_port=43001)
-        master.block_until_build_finished(build_id, timeout=10)
+        self.assertTrue(master.block_until_build_finished(build_id, timeout=30),
+                        'The build should finish building within the timeout.')
         self.assert_build_has_successful_status(build_id)

--- a/test/functional/master/test_endpoints.py
+++ b/test/functional/master/test_endpoints.py
@@ -27,7 +27,8 @@ class TestMasterEndpoints(BaseFunctionalTestCase):
         master, build_id = self._start_master_only_and_post_a_new_job()
 
         master.cancel_build(build_id)
-        master.block_until_build_finished(build_id)
+        self.assertTrue(master.block_until_build_finished(build_id, timeout=30),
+                        'The build should finish building within the timeout.')
 
         self.assert_build_has_canceled_status(build_id=build_id)
 

--- a/test/functional/master/test_http_timeout.py
+++ b/test/functional/master/test_http_timeout.py
@@ -42,13 +42,13 @@ class TestHttpTimeout(BaseFunctionalTestCase):
         })
         build_id = build_resp['build_id']
 
-        self.assertTrue(
-            master.block_until_slave_offline(unresponsive_slave_id, timeout=10),
-            'Unresponsive slave should be marked offline.')
+        self.assertTrue(master.block_until_slave_offline(unresponsive_slave_id, timeout=10),
+                        'Unresponsive slave should be marked offline.')
 
         # First slave should now be marked offline. Connect a real slave to finish the build.
         self.cluster.start_slaves(num_slaves=1, start_port=self.NORMAL_SLAVE_PORT)
-        master.block_until_build_finished(build_id, timeout=10)
+        self.assertTrue(master.block_until_build_finished(build_id, timeout=30),
+                        'The build should finish building within the timeout.')
         self.assert_build_has_successful_status(build_id)
 
 

--- a/test/functional/master/test_shutdown.py
+++ b/test/functional/master/test_shutdown.py
@@ -51,14 +51,14 @@ class TestShutdown(BaseFunctionalTestCase):
             'project_directory': project_dir.name,
             })
         build_id = build_resp['build_id']
-
-        master.block_until_build_started(build_id, timeout=10)
+        self.assertTrue(master.block_until_build_started(build_id, timeout=30),
+                        'The build should start building within the timeout.')
 
         # Shutdown one on the slaves and test if the build can still complete
         master.graceful_shutdown_slaves_by_id([1])
 
-        master.block_until_build_finished(build_id, timeout=30)
-
+        self.assertTrue(master.block_until_build_finished(build_id, timeout=30),
+                        'The build should finish building within the timeout.')
         self.assert_build_has_successful_status(build_id=build_id)
 
         slaves_response = master.get_slaves()

--- a/test/functional/test_cluster_basic.py
+++ b/test/functional/test_cluster_basic.py
@@ -30,7 +30,8 @@ class TestClusterBasic(BaseFunctionalTestCase):
             'project_directory': project_dir.name,
         })
         build_id = build_resp['build_id']
-        master.block_until_build_finished(build_id, timeout=30)
+        self.assertTrue(master.block_until_build_finished(build_id, timeout=30),
+                        'The build should finish building within the timeout.')
         slave.block_until_idle(timeout=20)  # ensure slave teardown has finished before making assertions
 
         self._assert_build_completed_as_expected(build_id, test_job_config, project_dir)
@@ -47,7 +48,8 @@ class TestClusterBasic(BaseFunctionalTestCase):
             'job_name': 'Simple',
         })
         build_id = build_resp['build_id']
-        master.block_until_build_finished(build_id, timeout=20)  # extra time here to allow for cloning the repo
+        self.assertTrue(master.block_until_build_finished(build_id, timeout=30),
+                        'The build should finish building within the timeout.')
 
         # Each atom of the demo project just echoes one of the numbers 1 through 10.
         expected_artifact_contents = [
@@ -93,8 +95,10 @@ class TestClusterBasic(BaseFunctionalTestCase):
             'project_directory': project_dir.name,
         })
 
-        master.block_until_build_finished(build_1['build_id'], timeout=30)
-        master.block_until_build_finished(build_2['build_id'], timeout=30)
+        self.assertTrue(master.block_until_build_finished(build_1['build_id'], timeout=45),
+                        'Build 1 should finish building within the timeout.')
+        self.assertTrue(master.block_until_build_finished(build_2['build_id'], timeout=45),
+                        'Build 2 should finish building within the timeout.')
         slave.block_until_idle(timeout=20)  # ensure slave teardown has finished before making assertions
 
         self._assert_build_completed_as_expected(build_1['build_id'], test_config, project_dir)


### PR DESCRIPTION
We see some flakiness in CI related to builds not being in an expected state at the end of a test. There are calls to block a test until a build reaches a certain state, but if the build doesn't reach that state within the timeout we currently just ignore that and continue on. This change adds assertions so that tests will fail immediately if a build is taking too long.

This is a step towards making sources of flakiness more obvious in the functional tests.