### PR TITLE
Refactor subjob start threading

### DIFF
--- a/app/common/metrics.py
+++ b/app/common/metrics.py
@@ -31,6 +31,7 @@ class ErrorType(str, Enum):
     NetworkRequestFailure = 'NetworkRequestFailure'
     PostBuildFailure = 'PostBuildFailure'
     SetupBuildFailure = 'SetupBuildFailure'
+    SubjobStartFailure = 'SubjobStartFailure'
     SubjobWriteFailure = 'SubjobWriteFailure'
     ZipFileCreationFailure = 'ZipFileCreationFailure'
 

--- a/app/master/build.py
+++ b/app/master/build.py
@@ -14,6 +14,7 @@ from app.common.build_artifact import BuildArtifact
 from app.common.metrics import build_state_duration_seconds, ErrorType, internal_errors, serialized_build_time_seconds
 from app.master.build_fsm import BuildFsm, BuildEvent, BuildState
 from app.master.build_request import BuildRequest
+from app.master.subjob import Subjob
 from app.project_type.project_type import ProjectType
 from app.util import util
 from app.util.conf.configuration import Configuration
@@ -190,12 +191,8 @@ class Build(object):
         """
         return [subjob for subjob in self._all_subjobs_by_id.values()]
 
-    def subjob(self, subjob_id):
-        """
-        Returns a single subjob
-        :type subjob_id: int
-        :rtype: Subjob
-        """
+    def subjob(self, subjob_id: int) -> Subjob:
+        """Return the subjob for this build with the specified id."""
         subjob = self._all_subjobs_by_id.get(subjob_id)
         if subjob is None:
             raise ItemNotFoundError('Invalid subjob id.')

--- a/app/master/subjob.py
+++ b/app/master/subjob.py
@@ -24,13 +24,16 @@ class Subjob(object):
         self._logger = get_logger(__name__)
         self._build_id = build_id
         self._subjob_id = subjob_id
-        self.project_type = project_type
+        self._project_type = project_type  # todo: Unused; remove.
         self.job_config = job_config
         self._atoms = atoms
         self._set_atoms_subjob_id(atoms, subjob_id)
         self._set_atom_state(AtomState.NOT_STARTED)
         self.timings = {}  # a dict, atom_ids are the keys and seconds are the values
         self.slave = None  # The slave that had been assigned this subjob. Is None if not started.
+
+    def __str__(self):
+        return '<subjob {} of build {}>'.format(self._subjob_id, self._build_id)
 
     def _set_atoms_subjob_id(self, atoms, subjob_id):
         """

--- a/app/util/network.py
+++ b/app/util/network.py
@@ -150,8 +150,8 @@ class Network(object):
         resp = self._session.request(method, url, data=data_to_send, timeout=timeout, *args, **kwargs)
         if not resp.ok and error_on_failure:
             internal_errors.labels(ErrorType.NetworkRequestFailure).inc()  # pylint: disable=no-member
-            raise _RequestFailedError('Request to {} failed with status_code {} and response "{}"'.
-                                      format(url, str(resp.status_code), resp.text))
+            raise RequestFailedError('Request to {} failed with status_code {} and response "{}"'.
+                                     format(url, str(resp.status_code), resp.text))
         return resp
 
     @staticmethod
@@ -201,5 +201,5 @@ class Network(object):
             return None
 
 
-class _RequestFailedError(Exception):
+class RequestFailedError(Exception):
     pass


### PR DESCRIPTION
This is a follow-up to my previous change to move subjob start off of `SafeThread` to avoid taking down the master service. This change further improves the behavior when a subjob start call fails.

- Instead of the `Slave` class starting a new thread to kick off a subjob, `ClusterMaster` starts the thread. This makes more sense since threads are only started to perform asynchronous actions in response to API requests and the `Slave` class shouldn't need to worry about that.
- In the case where a new subjob is not started and the slave is instead torn down, previously the teardown API call happened synchronously with the slave's API call to report a result (which is bad). The teardown API call is now asynchronous.
- Record error metric when subjob fails to start.
- Requeue subjobs when subjob fails to start because of a dead slave or an error on the slave side. Previously subjobs were only requeued if the slave was explicitly put in shutdown mode.