### PR TITLE
Refactor shutdown functional test to be more stable

### DIFF
--- a/test/functional/job_configs.py
+++ b/test/functional/job_configs.py
@@ -96,13 +96,12 @@ JobWithSetupAndTeardown:
     setup_build:
         - echo "Doing build setup."
         - sleep 1
-        - echo "setup." > $PROJECT_DIR/build_setup.txt
+        - echo "setup." >> $PROJECT_DIR/build_setup.txt
 
     commands:
         - echo "Doing subjob $SUBJOB_NUMBER."
         - sleep 1
         - MY_SUBJOB_FILE=$PROJECT_DIR/subjob_file_${SUBJOB_NUMBER}.txt
-        - cp build_setup.txt $MY_SUBJOB_FILE
         - echo "subjob $SUBJOB_NUMBER." >> $MY_SUBJOB_FILE
 
     atomizers:
@@ -111,8 +110,7 @@ JobWithSetupAndTeardown:
     teardown_build:
         - echo "Doing build teardown."
         - sleep 1
-        - ALL_SUBJOB_FILES=$(ls $PROJECT_DIR/subjob_file_*.txt || mktemp -t clusterrunnerXXXX)
-        - echo "teardown." | tee -a $ALL_SUBJOB_FILES
+        - echo "teardown." >> $PROJECT_DIR/build_teardown.txt
 
 """,
         'nt': """
@@ -123,13 +121,12 @@ JobWithSetupAndTeardown:
     setup_build:
         - echo Doing build setup.
         - ping 127.0.0.1 -n 2 >nul
-        - echo setup.> !PROJECT_DIR!\\build_setup.txt
+        - echo setup.>> !PROJECT_DIR!\\build_setup.txt
 
     commands:
         - echo Doing subjob !SUBJOB_NUMBER!.
         - ping 127.0.0.1 -n 2 >nul
         - set MY_SUBJOB_FILE=!PROJECT_DIR!\\subjob_file_!SUBJOB_NUMBER!.txt
-        - COPY build_setup.txt !MY_SUBJOB_FILE! >nul
         - echo subjob !SUBJOB_NUMBER!.>> !MY_SUBJOB_FILE!
 
     atomizers:
@@ -138,7 +135,7 @@ JobWithSetupAndTeardown:
     teardown_build:
         - echo Doing build teardown.
         - ping 127.0.0.1 -n 2 >nul
-        - FOR /l %n in (1,1,3) DO @echo teardown.>> !PROJECT_DIR!\\subjob_file_%n.txt
+        - echo teardown.>> !PROJECT_DIR!\\build_teardown.txt
 """,
     },
     expected_to_fail=False,
@@ -146,9 +143,10 @@ JobWithSetupAndTeardown:
     expected_num_atoms=3,
     expected_project_dir_contents=[
         File('build_setup.txt', contents='setup.\n'),
-        File('subjob_file_1.txt', contents='setup.\nsubjob 1.\nteardown.\n'),
-        File('subjob_file_2.txt', contents='setup.\nsubjob 2.\nteardown.\n'),
-        File('subjob_file_3.txt', contents='setup.\nsubjob 3.\nteardown.\n'),
+        File('subjob_file_1.txt', contents='subjob 1.\n'),
+        File('subjob_file_2.txt', contents='subjob 2.\n'),
+        File('subjob_file_3.txt', contents='subjob 3.\n'),
+        File('build_teardown.txt', contents='teardown.\n'),
     ],
 )
 

--- a/test/functional/test_cluster_basic.py
+++ b/test/functional/test_cluster_basic.py
@@ -84,16 +84,17 @@ class TestClusterBasic(BaseFunctionalTestCase):
         slave = self.cluster.start_slave(num_executors_per_slave=5, start_port=43001)
 
         # Start two builds.
-        project_dir = tempfile.TemporaryDirectory()
+        project_dir_1 = tempfile.TemporaryDirectory()
         build_1 = master.post_new_build({
             'type': 'directory',
             'config': job_config,
-            'project_directory': project_dir.name,
+            'project_directory': project_dir_1.name,
         })
+        project_dir_2 = tempfile.TemporaryDirectory()
         build_2 = master.post_new_build({
             'type': 'directory',
             'config': job_config,
-            'project_directory': project_dir.name,
+            'project_directory': project_dir_2.name,
         })
 
         self.assertTrue(master.block_until_build_finished(build_1['build_id'], timeout=45),
@@ -102,8 +103,8 @@ class TestClusterBasic(BaseFunctionalTestCase):
                         'Build 2 should finish building within the timeout.')
         slave.block_until_idle(timeout=20)  # ensure slave teardown has finished before making assertions
 
-        self._assert_build_completed_as_expected(build_1['build_id'], test_config, project_dir)
-        self._assert_build_completed_as_expected(build_2['build_id'], test_config, project_dir)
+        self._assert_build_completed_as_expected(build_1['build_id'], test_config, project_dir_1)
+        self._assert_build_completed_as_expected(build_2['build_id'], test_config, project_dir_2)
 
     def test_failed_setup_does_not_kill_slave(self):
         master = self.cluster.start_master()


### PR DESCRIPTION
This test has been flaky on Windows because of parallel subjobs all trying to copy the same file. This refactors the test config to be simpler and not rely on a copy. The test asserts on both the project directory file list and file contents at the end of the test, so the copy is not really necessary.