### PR TITLE
Add v2 API routes

### DIFF
--- a/app/web_framework/cluster_base_handler.py
+++ b/app/web_framework/cluster_base_handler.py
@@ -157,7 +157,7 @@ class ClusterBaseAPIHandler(ClusterBaseHandler):
         """
         if self._route_node is None:
             raise RuntimeError('This handler ({}) is not associated with a RouteNode'.format(type(self).__name__))
-        return {child.label: child.route_template() for child in self._route_node.children}
+        return {child.label: child.route_template() for child in self._route_node.get_children(self.api_version)}
 
     def set_default_headers(self):
         self.set_header('Content-Type', 'application/json')

--- a/app/web_framework/cluster_slave_application.py
+++ b/app/web_framework/cluster_slave_application.py
@@ -18,33 +18,59 @@ class ClusterSlaveApplication(ClusterApplication):
         }
         # The routes are described using a tree structure.  This is a better representation of a path than a flat list
         #  of strings and allows us to inspect children/parents of a node to generate 'child routes'
-        root_route = \
-            RouteNode(r'/', _RootHandler).add_children([
-                RouteNode(r'v1', _APIVersionOneHandler).add_children([
-                    RouteNode(r'version', _VersionHandler),
-                    RouteNode(r'build', _BuildsHandler, 'builds').add_children([
-                        RouteNode(r'(\d+)', _BuildHandler, 'build').add_children([
-                            RouteNode(r'setup', _BuildSetupHandler),
-                            RouteNode(r'teardown', _TeardownHandler),
-                            RouteNode(r'subjob', _SubjobsHandler, 'subjobs').add_children([
-                                RouteNode(r'(\d+)', _SubjobHandler, 'subjob').add_children([
-                                    RouteNode(r'atom', _AtomsHandler, 'atoms').add_children([
-                                        RouteNode(r'(\d+)', _AtomHandler).add_children([
-                                            RouteNode(r'console', _AtomConsoleHandler)
-                                        ])
+        api_v1 = [
+            RouteNode(r'v1', _APIVersionOneHandler).add_children([
+                RouteNode(r'version', _VersionHandler),
+                RouteNode(r'build', _BuildsHandler, 'builds').add_children([
+                    RouteNode(r'(\d+)', _BuildHandler, 'build').add_children([
+                        RouteNode(r'setup', _BuildSetupHandler),
+                        RouteNode(r'teardown', _TeardownHandler),
+                        RouteNode(r'subjob', _SubjobsHandler, 'subjobs').add_children([
+                            RouteNode(r'(\d+)', _SubjobHandler, 'subjob').add_children([
+                                RouteNode(r'atom', _AtomsHandler, 'atoms').add_children([
+                                    RouteNode(r'(\d+)', _AtomHandler).add_children([
+                                        RouteNode(r'console', _AtomConsoleHandler)
                                     ])
                                 ])
                             ])
                         ])
-                    ]),
-                    RouteNode(r'executor', _ExecutorsHandler, 'executors').add_children([
-                        RouteNode(r'(\d+)', _ExecutorHandler, 'executor')
-                    ]),
-                    RouteNode(r'eventlog', _EventlogHandler),
-                    RouteNode(r'kill', _KillHandler)
+                    ])
+                ]),
+                RouteNode(r'executor', _ExecutorsHandler, 'executors').add_children([
+                    RouteNode(r'(\d+)', _ExecutorHandler, 'executor')
+                ]),
+                RouteNode(r'eventlog', _EventlogHandler),
+                RouteNode(r'kill', _KillHandler)
+            ])]
+
+        api_v2 = [
+            RouteNode(r'version', _VersionHandler),
+            RouteNode(r'build', _BuildsHandler, 'builds').add_children([
+                RouteNode(r'(\d+)', _BuildHandler, 'build').add_children([
+                    RouteNode(r'setup', _BuildSetupHandler),
+                    RouteNode(r'teardown', _TeardownHandler),
+                    RouteNode(r'subjob', _SubjobsHandler, 'subjobs').add_children([
+                        RouteNode(r'(\d+)', _SubjobHandler, 'subjob').add_children([
+                            RouteNode(r'atom', _AtomsHandler, 'atoms').add_children([
+                                RouteNode(r'(\d+)', _AtomHandler).add_children([
+                                    RouteNode(r'console', _AtomConsoleHandler)
+                                ])
+                            ])
+                        ])
+                    ])
                 ])
-            ])
-        handlers = self.get_all_handlers(root_route, default_params)
+            ]),
+            RouteNode(r'executor', _ExecutorsHandler, 'executors').add_children([
+                RouteNode(r'(\d+)', _ExecutorHandler, 'executor')
+            ]),
+            RouteNode(r'eventlog', _EventlogHandler),
+            RouteNode(r'kill', _KillHandler)]
+
+        root = RouteNode(r'/', _RootHandler)
+        root.add_children(api_v1, version=1)
+        root.add_children(api_v2, version=2)
+
+        handlers = self.get_all_handlers(root, default_params)
         super().__init__(handlers)
 
 

--- a/app/web_framework/cluster_slave_application.py
+++ b/app/web_framework/cluster_slave_application.py
@@ -45,13 +45,13 @@ class ClusterSlaveApplication(ClusterApplication):
 
         api_v2 = [
             RouteNode(r'version', _VersionHandler),
-            RouteNode(r'build', _BuildsHandler, 'builds').add_children([
+            RouteNode(r'builds', _BuildsHandler, 'builds').add_children([
                 RouteNode(r'(\d+)', _BuildHandler, 'build').add_children([
                     RouteNode(r'setup', _BuildSetupHandler),
                     RouteNode(r'teardown', _TeardownHandler),
-                    RouteNode(r'subjob', _SubjobsHandler, 'subjobs').add_children([
+                    RouteNode(r'subjobs', _SubjobsHandler, 'subjobs').add_children([
                         RouteNode(r'(\d+)', _SubjobHandler, 'subjob').add_children([
-                            RouteNode(r'atom', _AtomsHandler, 'atoms').add_children([
+                            RouteNode(r'atoms', _AtomsHandler, 'atoms').add_children([
                                 RouteNode(r'(\d+)', _AtomHandler).add_children([
                                     RouteNode(r'console', _AtomConsoleHandler)
                                 ])

--- a/app/web_framework/route_node.py
+++ b/app/web_framework/route_node.py
@@ -1,5 +1,5 @@
 import inspect
-from typing import Optional
+from typing import Optional, List
 
 
 class RouteNode(object):
@@ -51,12 +51,10 @@ class RouteNode(object):
                     return '[{}]'.format(get_params[-1])
         return self.regex_part
 
-    def add_children(self, child_nodes: list, version: Optional[int]=None):
+    def add_children(self, child_nodes: List['RouteNode'], version: Optional[int]=None) -> 'RouteNode':
         """
         Build the tree structure by adding child RouteNodes to this RouteNode.  Can be chained.
-        :type child_nodes: list[RouteNode]
         :param version: The API version assigned to all children routes
-        :rtype: RouteNode
         """
         self.children += child_nodes
         for node in child_nodes:
@@ -65,7 +63,7 @@ class RouteNode(object):
                 node.assign_version_to_all_children(version)
         return self
 
-    def get_children(self, version: int):
+    def get_children(self, version: int) -> List['RouteNode']:
         """
         Get all children routes that have the same version as requested.
         :param version: The requested version.

--- a/app/web_framework/route_node.py
+++ b/app/web_framework/route_node.py
@@ -1,20 +1,18 @@
 import inspect
+from typing import Optional
 
 
 class RouteNode(object):
     """
     A tree data structure for representing the parts of a url path, for routing.
     """
-    def __init__(self, regex_part, handler, label=None, version=None):
+    def __init__(self, regex_part: str, handler: type, label: Optional[str]=None, version: Optional[int]=None):
         """
-        :param regex_part: To generate the regex the web framework will use to match this route, we combine a set of
-        regex_parts: The regex_part in this node and the regex_parts in all its ancestor nodes.
-        :type regex_part: str
+        :param regex_part: To generate the regex the web framework will use to match this route, we combine
+        a set of regex_parts: The regex_part in this node and the regex_parts in all its ancestor nodes.
         :param handler: The handler class that will be instantiated by the web framework when this route is hit.
-        :type handler: type
         :param label: A human-friendly label for the objects returned by this route, ie "builds"
         :param version: The API version assigned to this route
-        :type label: str | None
         """
         self.label = label or regex_part
         self.regex_part = regex_part
@@ -53,7 +51,7 @@ class RouteNode(object):
                     return '[{}]'.format(get_params[-1])
         return self.regex_part
 
-    def add_children(self, child_nodes, version=None):
+    def add_children(self, child_nodes: list, version: Optional[int]=None):
         """
         Build the tree structure by adding child RouteNodes to this RouteNode.  Can be chained.
         :type child_nodes: list[RouteNode]


### PR DESCRIPTION
Add v2 API routes to both the slave and master services. These routes are assuming that there are no collisions with the route URIs, which is safe to assume for now since all v1 API paths are under `/v1/...` and all v2 API paths are just under `/...`

## What's changed

The `RouteNode` class now has a method that returns all child routes that have the same version requested. So when we get children now we don't want to use `self._route_node.children` but instead use `self._route_node.get_children(self.api_version)` to make sure we only get the children routes that have the correct version.

We want to use this for the root route, since it has both v1 and v2 routes as children. This way, when a request to v1 of the API is made on the route now, we will only show the child routes that are also from v1, etc.