### PR TITLE
Add pagination to v2 endpoints subjobs & atoms

### DIFF
--- a/app/master/build.py
+++ b/app/master/build.py
@@ -194,11 +194,6 @@ class Build(object):
         """
         num_subjobs = len(self._all_subjobs_by_id)
         start, end = get_paginated_indices(offset, limit, num_subjobs)
-
-        # Offset request/starting index is out of bounds, so return no results.
-        if start > num_subjobs:
-            return []
-
         requested_subjobs = islice(self._all_subjobs_by_id, start, end)
         return [self._all_subjobs_by_id[key] for key in requested_subjobs]
 

--- a/app/master/build.py
+++ b/app/master/build.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
 from enum import Enum
+from itertools import islice
 import os
 from queue import Queue, Empty
 import shutil
@@ -8,7 +9,7 @@ from threading import Lock, Thread
 import time
 import uuid
 
-from typing import Dict
+from typing import Dict, List
 
 from app.common.build_artifact import BuildArtifact
 from app.common.metrics import build_state_duration_seconds, ErrorType, internal_errors, serialized_build_time_seconds
@@ -22,6 +23,7 @@ from app.util.counter import Counter
 from app.util.exceptions import ItemNotFoundError
 import app.util.fs
 from app.util.log import get_logger
+from app.util.pagination import get_paginated_indices
 from app.util.single_use_coin import SingleUseCoin
 
 
@@ -61,7 +63,7 @@ class Build(object):
         self._project_type = None
         self._build_completion_lock = Lock()  # protects against more than one thread detecting the build's finish
 
-        self._all_subjobs_by_id = {}
+        self._all_subjobs_by_id = OrderedDict()
         self._unstarted_subjobs = None  # WIP(joey): Move subjob queues to BuildScheduler class.
         self._finished_subjobs = None
         self._failed_atoms = None
@@ -184,12 +186,21 @@ class Build(object):
         """
         return self._build_request
 
-    def all_subjobs(self):
+    def all_subjobs(self, offset: int=None, limit: int=None) -> List['Subjob']:
         """
         Returns a list of subjobs for this build
-        :rtype: list[Subjob]
+        :param offset: The starting index of the requested build
+        :param limit: The number of builds requested
         """
-        return [subjob for subjob in self._all_subjobs_by_id.values()]
+        num_subjobs = len(self._all_subjobs_by_id)
+        start, end = get_paginated_indices(offset, limit, num_subjobs)
+
+        # Offset request/starting index is out of bounds, so return no results.
+        if start > num_subjobs:
+            return []
+
+        requested_subjobs = islice(self._all_subjobs_by_id, start, end)
+        return [self._all_subjobs_by_id[key] for key in requested_subjobs]
 
     def subjob(self, subjob_id: int) -> Subjob:
         """Return the subjob for this build with the specified id."""

--- a/app/master/build.py
+++ b/app/master/build.py
@@ -186,7 +186,7 @@ class Build(object):
         """
         return self._build_request
 
-    def all_subjobs(self, offset: int=None, limit: int=None) -> List['Subjob']:
+    def get_subjobs(self, offset: int=None, limit: int=None) -> List['Subjob']:
         """
         Returns a list of subjobs for this build
         :param offset: The starting index of the requested build

--- a/app/master/build_request_handler.py
+++ b/app/master/build_request_handler.py
@@ -91,7 +91,7 @@ class BuildRequestHandler(object):
                     analytics.record_event(analytics.BUILD_PREPARE_FINISH, build_id=build.build_id(), is_success=True,
                                            log_msg='Build {build_id} successfully prepared.')
                     # If the atomizer found no work to do, perform build cleanup and skip the slave allocation.
-                    if len(build.all_subjobs()) == 0:
+                    if len(build.get_subjobs()) == 0:
                         self._logger.info('Build {} has no work to perform and is exiting.', build.build_id())
                         build.finish()
                     # If there is work to be done, this build must queue to be allocated slaves.

--- a/app/master/build_scheduler.py
+++ b/app/master/build_scheduler.py
@@ -57,7 +57,7 @@ class BuildScheduler(object):
             return False
         if self._build._unstarted_subjobs.empty():
             return False
-        if self._num_executors_allocated >= len(self._build.all_subjobs()):
+        if self._num_executors_allocated >= len(self._build.get_subjobs()):
             return False
         return True
 

--- a/app/master/cluster_master.py
+++ b/app/master/cluster_master.py
@@ -17,6 +17,7 @@ from app.util.conf.configuration import Configuration
 from app.util.exceptions import BadRequestError, ItemNotFoundError, ItemNotReadyError
 from app.util import fs
 from app.util.log import get_logger
+from app.util.pagination import get_paginated_indices
 
 
 class ClusterMaster(ClusterService):
@@ -71,26 +72,13 @@ class ClusterMaster(ClusterService):
         :param limit: The number of builds requested
         """
         num_builds = len(self._all_builds_by_id)
+        start, end = get_paginated_indices(offset, limit, num_builds)
 
-        # If offset & limit are not set, return all builds (don't break `/v1/build/`)
-        offset = offset if offset is not None else 0
-        limit = limit if limit is not None else num_builds
-
-        # Remove any negative values
-        offset = max(offset, 0)
-        limit = max(limit, 0)
-
-        # If limit is set higher than the number of builds, reduce limit
-        limit = min(num_builds, limit)
-
-        # Requested offset too high should yield no results
-        if offset > num_builds:
+        # Offset request/starting index is out of bounds, so return no results.
+        if start > num_builds:
             return []
 
-        starting_index = offset
-        ending_index = min((starting_index + limit), num_builds)
-
-        requested_builds = islice(self._all_builds_by_id, starting_index, ending_index)
+        requested_builds = islice(self._all_builds_by_id, start, end)
         return [self._all_builds_by_id[key] for key in requested_builds]
 
     def active_builds(self):

--- a/app/master/cluster_master.py
+++ b/app/master/cluster_master.py
@@ -73,11 +73,6 @@ class ClusterMaster(ClusterService):
         """
         num_builds = len(self._all_builds_by_id)
         start, end = get_paginated_indices(offset, limit, num_builds)
-
-        # Offset request/starting index is out of bounds, so return no results.
-        if start > num_builds:
-            return []
-
         requested_builds = islice(self._all_builds_by_id, start, end)
         return [self._all_builds_by_id[key] for key in requested_builds]
 

--- a/app/master/cluster_master.py
+++ b/app/master/cluster_master.py
@@ -65,7 +65,7 @@ class ClusterMaster(ClusterService):
             'slaves': slaves_representation,
         }
 
-    def builds(self, offset: int=None, limit: int=None) -> List['Build']:
+    def get_builds(self, offset: int=None, limit: int=None) -> List['Build']:
         """
         Returns a list of all builds.
         :param offset: The starting index of the requested build
@@ -86,7 +86,7 @@ class ClusterMaster(ClusterService):
         Returns a list of incomplete builds
         :rtype: list[Build]
         """
-        return [build for build in self.builds() if not build.is_finished]
+        return [build for build in self.get_builds() if not build.is_finished]
 
     def all_slaves_by_id(self):
         """

--- a/app/master/subjob.py
+++ b/app/master/subjob.py
@@ -1,9 +1,11 @@
 import os
+from typing import List
 
 from app.common.build_artifact import BuildArtifact
 from app.master.atom import AtomState
 from app.util.conf.configuration import Configuration
 from app.util.log import get_logger
+from app.util.pagination import get_paginated_indices
 
 
 class Subjob(object):
@@ -85,11 +87,27 @@ class Subjob(object):
         }
 
     @property
-    def atoms(self):
+    def atoms(self) -> List['Atom']:
         """
-        :rtype: list[app.master.atom.Atom]
+        Returns a list of all atoms for this subjob
         """
         return self._atoms
+
+    def get_atoms(self, offset: int=None, limit: int=None) -> List['Atom']:
+        """
+        Returns a list of atoms for this subjob
+        :param offset: The starting index of the requested build
+        :param limit: The number of builds requested
+        :rtype: list[app.master.atom.Atom]
+        """
+        num_atoms = len(self._atoms)
+        start, end = get_paginated_indices(offset, limit, num_atoms)
+
+        # Offset request/starting index is out of bounds, so return no results.
+        if start > num_atoms:
+            return []
+
+        return self._atoms[start:end]
 
     def build_id(self):
         """

--- a/app/master/subjob.py
+++ b/app/master/subjob.py
@@ -103,10 +103,6 @@ class Subjob(object):
         num_atoms = len(self._atoms)
         start, end = get_paginated_indices(offset, limit, num_atoms)
 
-        # Offset request/starting index is out of bounds, so return no results.
-        if start > num_atoms:
-            return []
-
         return self._atoms[start:end]
 
     def build_id(self):

--- a/app/master/subjob.py
+++ b/app/master/subjob.py
@@ -102,7 +102,6 @@ class Subjob(object):
         """
         num_atoms = len(self._atoms)
         start, end = get_paginated_indices(offset, limit, num_atoms)
-
         return self._atoms[start:end]
 
     def build_id(self):

--- a/app/util/pagination.py
+++ b/app/util/pagination.py
@@ -1,0 +1,27 @@
+from typing import Optional, Tuple
+
+
+def get_paginated_indices(offset: Optional[int], limit: Optional[int], length: int) -> Tuple[int, int]:  # pylint: disable=invalid-sequence-index
+    """
+    Given an offset and a limit, return the correct starting and ending indices to paginate with that are valid within
+    a given length of the item being paginated.
+    :param offset: The offset from the starting item for the request
+    :param limit: The limit or amount of items for the request
+    :param length: The length of the list which we are getting indices to paginate
+    """
+    # Either both limit and offset are set set or neither are set, so if one or more isn't set
+    # then we return the entire list. This usually implies `v1` is being called where we don't paginate at all.
+    if offset is None or limit is None:
+        return 0, length
+
+    # Remove any negative values.
+    offset = max(offset, 0)
+    limit = max(limit, 0)
+
+    # If limit is set higher than the number of builds, reduce limit.
+    limit = min(length, limit)
+
+    starting_index = offset
+    ending_index = min((starting_index + limit), length)
+
+    return starting_index, ending_index

--- a/app/web_framework/cluster_master_application.py
+++ b/app/web_framework/cluster_master_application.py
@@ -146,7 +146,7 @@ class _SubjobsHandler(_ClusterMasterBaseAPIHandler):
     def get(self, build_id):
         build = self._cluster_master.get_build(int(build_id))
         response = {
-            'subjobs': [subjob.api_representation() for subjob in build.all_subjobs()]
+            'subjobs': [subjob.api_representation() for subjob in build.get_subjobs()]
         }
         self.write(response)
 
@@ -156,7 +156,7 @@ class _V2SubjobsHandler(_SubjobsHandler):
         offset, limit = self.get_pagination_params()
         build = self._cluster_master.get_build(int(build_id))
         response = {
-            'subjobs': [subjob.api_representation() for subjob in build.all_subjobs(offset, limit)]
+            'subjobs': [subjob.api_representation() for subjob in build.get_subjobs(offset, limit)]
         }
         self.write(response)
 
@@ -279,7 +279,7 @@ class _BuildsHandler(_ClusterMasterBaseAPIHandler):
 
     def get(self):
         response = {
-            'builds': [build.api_representation() for build in self._cluster_master.builds()]
+            'builds': [build.api_representation() for build in self._cluster_master.get_builds()]
         }
         self.write(response)
 
@@ -288,7 +288,7 @@ class _V2BuildsHandler(_BuildsHandler):
     def get(self):
         offset, limit = self.get_pagination_params()
         response = {
-            'builds': [build.api_representation() for build in self._cluster_master.builds(offset, limit)]
+            'builds': [build.api_representation() for build in self._cluster_master.get_builds(offset, limit)]
         }
         self.write(response)
 

--- a/test/unit/master/test_build.py
+++ b/test/unit/master/test_build.py
@@ -142,7 +142,7 @@ class TestBuild(BaseUnitTestCase):
         fake_atom_exit_code = 777
         mock_open(mock=self.mock_open, read_data=str(fake_atom_exit_code))
         build = self._create_test_build(BuildStatus.BUILDING, num_subjobs=1, num_atoms_per_subjob=1)
-        subjob = build.all_subjobs()[0]
+        subjob = build.get_subjobs()[0]
 
         build.complete_subjob(subjob.subjob_id(), payload=self._FAKE_PAYLOAD)
 
@@ -155,7 +155,7 @@ class TestBuild(BaseUnitTestCase):
 
     def test_complete_subjob_marks_atoms_of_subjob_as_completed(self):
         build = self._create_test_build(BuildStatus.BUILDING)
-        subjob = build.all_subjobs()[0]
+        subjob = build.get_subjobs()[0]
 
         build.complete_subjob(subjob.subjob_id(), payload=self._FAKE_PAYLOAD)
 
@@ -164,7 +164,7 @@ class TestBuild(BaseUnitTestCase):
 
     def test_complete_subjob_writes_and_extracts_payload_to_correct_directory(self):
         build = self._create_test_build(BuildStatus.BUILDING)
-        subjob = build.all_subjobs()[0]
+        subjob = build.get_subjobs()[0]
 
         payload = {'filename': 'turtles.txt', 'body': 'Heroes in a half shell.'}
         build.complete_subjob(subjob.subjob_id(), payload=payload)
@@ -175,7 +175,7 @@ class TestBuild(BaseUnitTestCase):
 
     def test_exception_is_raised_if_problem_occurs_writing_subjob(self):
         build = self._create_test_build(BuildStatus.BUILDING)
-        subjob = build.all_subjobs()[0]
+        subjob = build.get_subjobs()[0]
 
         self.mock_util.fs.write_file.side_effect = FileExistsError
 

--- a/test/unit/master/test_build_request_handler.py
+++ b/test/unit/master/test_build_request_handler.py
@@ -16,7 +16,7 @@ class TestBuildRequestHandler(BaseUnitTestCase):
         build_request_handler = BuildRequestHandler(build_scheduler_mock)
         build_mock = self.patch('app.master.build.Build').return_value
         build_mock.has_error = False
-        build_mock.all_subjobs.return_value = subjobs
+        build_mock.get_subjobs.return_value = subjobs
 
         build_request_handler._prepare_build_async(build_mock, mock_project_lock)
 

--- a/test/unit/master/test_cluster_master.py
+++ b/test/unit/master/test_cluster_master.py
@@ -303,7 +303,7 @@ class TestClusterMaster(BaseUnitTestCase):
             build_mock.build_id = build_id
             master._all_builds_by_id[build_id] = build_mock
 
-        requested_builds = master.builds(offset, limit)
+        requested_builds = master.get_builds(offset, limit)
 
         id_of_first_build = requested_builds[0].build_id if len(requested_builds) else None
         id_of_last_build = requested_builds[-1].build_id if len(requested_builds) else None
@@ -367,7 +367,7 @@ class TestClusterMaster(BaseUnitTestCase):
             subjob_mock.subjob_id = subjob_id
             build._all_subjobs_by_id[subjob_id] = subjob_mock
 
-        requested_subjobs = build.all_subjobs(offset, limit)
+        requested_subjobs = build.get_subjobs(offset, limit)
 
         id_of_first_subjob = requested_subjobs[0].subjob_id if len(requested_subjobs) else None
         id_of_last_subjob = requested_subjobs[-1].subjob_id if len(requested_subjobs) else None
@@ -419,7 +419,7 @@ class TestClusterMaster(BaseUnitTestCase):
             None
         ),
     )
-    def test_subjobs_with_pagination_request(
+    def test_atoms_with_pagination_request(
             self,
             offset: Optional[int],
             limit: Optional[int],


### PR DESCRIPTION
This adds the same pagination logic as the v2 builds endpoint in https://github.com/box/ClusterRunner/pull/394 but to subjobs and atoms.

I've abstracted some of the logic that was in the builds endpoint to a more generic utility method for taking an offset, limit, and list length and producing the paginated indices. 

A lot of this logic is very similar to https://github.com/box/ClusterRunner/pull/394, so there shouldn't be anything too surprising here