### PR TITLE
Fix build cancel when BUILDING

### DIFF
--- a/app/master/build.py
+++ b/app/master/build.py
@@ -416,7 +416,7 @@ class Build(object):
     @property
     def is_finished(self):
         # WIP(joey): Calling logic should check _is_canceled if it needs to instead of including the check here.
-        return self._is_canceled() or self._postbuild_tasks_are_finished
+        return self.is_canceled or self._postbuild_tasks_are_finished
 
     @property
     def _detail_message(self):
@@ -438,7 +438,8 @@ class Build(object):
     def has_error(self):
         return self._status() is BuildState.ERROR
 
-    def _is_canceled(self):
+    @property
+    def is_canceled(self):
         return self._status() is BuildState.CANCELED
 
     def _is_stopped(self):
@@ -451,7 +452,7 @@ class Build(object):
         :rtype: list[Atom] | None
         """
         if self._failed_atoms is None and self.is_finished:
-            if self._is_canceled():
+            if self.is_canceled:
                 return []
 
             self._failed_atoms = []
@@ -470,7 +471,7 @@ class Build(object):
             NO_FAILURES:
         :rtype: BuildResult | None
         """
-        if self._is_canceled():
+        if self.is_canceled:
             return BuildResult.FAILURE
 
         if self.is_finished:

--- a/test/unit/master/test_build_scheduler.py
+++ b/test/unit/master/test_build_scheduler.py
@@ -1,0 +1,86 @@
+from queue import Queue
+from unittest.mock import Mock
+
+from app.master.build import Build
+from app.master.build_scheduler import BuildScheduler
+from app.master.build_scheduler_pool import BuildSchedulerPool
+from app.master.job_config import JobConfig
+from app.master.slave import Slave
+from app.master.subjob import Subjob
+from test.framework.base_unit_test_case import BaseUnitTestCase
+
+
+class TestBuildScheduler(BaseUnitTestCase):
+
+    def _get_mock_build(self):
+        mock_build = Mock(Build)
+        mock_build.is_canceled = True
+        config_mock = Mock(JobConfig, **{'max_executors': 20, 'max_executors_per_slave': 10})
+        mock_build.project_type.job_config.return_value = config_mock
+        # We modify the protected member variable because the build_scheduler class
+        # utilizes it directly.
+        mock_build._unstarted_subjobs = Queue(maxsize=10)
+        return mock_build
+
+    def test_execute_next_subjob_or_free_executor_with_canceled_build_frees_executor(self):
+        # Arrange
+        mock_build = self._get_mock_build()
+        mock_build.is_canceled = True
+        mock_slave = Mock(Slave, **{'num_executors': 10, 'id': 1})
+
+        # Act
+        scheduler = BuildScheduler(mock_build, Mock(BuildSchedulerPool))
+        scheduler.allocate_slave(mock_slave)
+        scheduler.execute_next_subjob_or_free_executor(mock_slave)
+
+        # Assert
+        mock_slave.free_executor.assert_called_once_with()
+
+    def test_executor_or_free_with_canceled_build_tearsdown_and_unallocates_when_all_free(self):
+        # Arrange
+        mock_build = self._get_mock_build()
+        mock_build.is_canceled = True
+        mock_slave = Mock(Slave, **{'num_executors': 10, 'id': 1})
+        mock_slave.free_executor.return_value = 0
+
+        # Act
+        scheduler = BuildScheduler(mock_build, Mock(BuildSchedulerPool))
+        scheduler.allocate_slave(mock_slave)
+        scheduler.execute_next_subjob_or_free_executor(mock_slave)
+
+        # Assert
+        mock_slave.free_executor.assert_called_once_with()
+        mock_slave.teardown.assert_called_once_with()
+
+    def test_execute_next_subjob_or_free_executor_with_no_unstarted_subjobs_frees_executors(self):
+        # Arrange
+        mock_build = self._get_mock_build()
+        mock_build.is_canceled = False
+        mock_build._unstarted_subjobs = Queue(maxsize=10)
+        mock_slave = Mock(Slave, **{'num_executors': 10, 'id': 1})
+
+        # Act
+        scheduler = BuildScheduler(mock_build, Mock(BuildSchedulerPool))
+        scheduler.allocate_slave(mock_slave)
+        scheduler.execute_next_subjob_or_free_executor(mock_slave)
+
+        # Assert
+        mock_slave.free_executor.assert_called_once_with()
+
+    def test_executor_or_free_starts_subjob_and_marks_build_in_progress(self):
+        # Arrange
+        mock_build = self._get_mock_build()
+        mock_build.is_canceled = False
+        mock_build._unstarted_subjobs = Queue(maxsize=10)
+        mock_subjob = Mock(Subjob)
+        mock_build._unstarted_subjobs.put(mock_subjob)
+        mock_slave = Mock(Slave, **{'num_executors': 10, 'id': 1})
+
+        # Act
+        scheduler = BuildScheduler(mock_build, Mock(BuildSchedulerPool))
+        scheduler.allocate_slave(mock_slave)
+        scheduler.execute_next_subjob_or_free_executor(mock_slave)
+
+        # Assert
+        mock_slave.start_subjob.assert_called_once_with(mock_subjob)
+        mock_subjob.mark_in_progress.assert_called_once_with(mock_slave)


### PR DESCRIPTION
This PR addresses an issue where it is possible for slaves to get stuck working on a canceled build. 

This is what currently happens when the state is BUILDING and it is canceled.

1. Slaves are assigned to a build
2. Subjobs are distributed among slaves
3. Subjob completes
4. Slave reports results back to the master
5. Master skips logic to mark subjob complete, reassign subjobs, or free the executor

Step 5 is the most critical part. A slave cannot stop working on a build until all of it's executors are freed. This PR modifies the flow so it looks like this. Steps 1 - 4 are the same.

5. Master marks subjob complete
6. Slave executor is freed
7. When executor count is 0, slave teardown is called
8. Slave returns back to the pool
9. No new slaves are allocated to the build
