### PR TITLE
Migrate builds from master to BuildStore

### DIFF
--- a/app/master/build_store.py
+++ b/app/master/build_store.py
@@ -6,7 +6,7 @@ from app.master.build import Build
 from app.util.exceptions import ItemNotFoundError
 
 
-class BuildStore():
+class BuildStore:
     """
     Build storage service that stores and handles all builds.
     """

--- a/app/master/build_store.py
+++ b/app/master/build_store.py
@@ -6,7 +6,7 @@ from app.master.build import Build
 from app.util.exceptions import ItemNotFoundError
 
 
-class BuildStore(object):
+class BuildStore():
     """
     Build storage service that stores and handles all builds.
     """
@@ -25,11 +25,12 @@ class BuildStore(object):
         return build
 
     @classmethod
-    def get_range(cls, start: int, end: int) -> List['Build']:
+    def get_range(cls, start: int, end: int) -> List[Build]:
         """
         Returns a list of all builds.
         :param start: The starting index of the requested build
-        :param end: The number of builds requested
+        :param end: 1 + the index of the last requested element, although if this is greater than the total number
+                    of builds available the length of the returned list may be smaller than (end - start)
         """
         requested_builds = islice(cls._all_builds_by_id, start, end)
         return [cls._all_builds_by_id[key] for key in requested_builds]

--- a/app/master/build_store.py
+++ b/app/master/build_store.py
@@ -1,0 +1,50 @@
+from collections import OrderedDict
+from itertools import islice
+from typing import List
+
+from app.master.build import Build
+from app.util.exceptions import ItemNotFoundError
+
+
+class BuildStore(object):
+    """
+    Build storage service that stores and handles all builds.
+    """
+    _all_builds_by_id = OrderedDict()
+
+    @classmethod
+    def get(cls, build_id: int) -> Build:
+        """
+        Returns a build by id
+        :param build_id: The id for the build whose status we are getting
+        """
+        build = cls._all_builds_by_id.get(build_id)
+        if build is None:
+            raise ItemNotFoundError('Invalid build id: {}.'.format(build_id))
+
+        return build
+
+    @classmethod
+    def get_range(cls, start: int, end: int) -> List['Build']:
+        """
+        Returns a list of all builds.
+        :param offset: The starting index of the requested build
+        :param limit: The number of builds requested
+        """
+        requested_builds = islice(cls._all_builds_by_id, start, end)
+        return [cls._all_builds_by_id[key] for key in requested_builds]
+
+    @classmethod
+    def add(cls, build: Build):
+        """
+        Add new build to collection
+        :param build: The build to add to the store
+        """
+        cls._all_builds_by_id[build.build_id()] = build
+
+    @classmethod
+    def size(cls) -> int:
+        """
+        Return the amount of builds within the store
+        """
+        return len(cls._all_builds_by_id)

--- a/app/master/build_store.py
+++ b/app/master/build_store.py
@@ -28,8 +28,8 @@ class BuildStore(object):
     def get_range(cls, start: int, end: int) -> List['Build']:
         """
         Returns a list of all builds.
-        :param offset: The starting index of the requested build
-        :param limit: The number of builds requested
+        :param start: The starting index of the requested build
+        :param end: The number of builds requested
         """
         requested_builds = islice(cls._all_builds_by_id, start, end)
         return [cls._all_builds_by_id[key] for key in requested_builds]

--- a/app/master/cluster_master.py
+++ b/app/master/cluster_master.py
@@ -326,7 +326,7 @@ class ClusterMaster(ClusterService):
         :param is_tar_request: If true, download the tar.gz archive instead of a zip.
         :return: The path to the archived results file
         """
-        build = BuildStore.get(build_id)  # type: Build
+        build = BuildStore.get(build_id)
         if build is None:
             raise ItemNotFoundError('Invalid build id.')
 

--- a/app/master/cluster_master.py
+++ b/app/master/cluster_master.py
@@ -1,6 +1,4 @@
-from collections import OrderedDict
 from concurrent.futures import ThreadPoolExecutor
-from itertools import islice
 import os
 from typing import List
 
@@ -10,6 +8,7 @@ from app.master.build import Build, MAX_SETUP_FAILURES
 from app.master.build_request import BuildRequest
 from app.master.build_request_handler import BuildRequestHandler
 from app.master.build_scheduler_pool import BuildSchedulerPool
+from app.master.build_store import BuildStore
 from app.master.slave import Slave
 from app.master.slave_allocator import SlaveAllocator
 from app.slave.cluster_slave import SlaveState
@@ -31,7 +30,6 @@ class ClusterMaster(ClusterService):
         self._logger = get_logger(__name__)
         self._master_results_path = Configuration['results_directory']
         self._all_slaves_by_url = {}
-        self._all_builds_by_id = OrderedDict()
         self._scheduler_pool = BuildSchedulerPool()
         self._build_request_handler = BuildRequestHandler(self._scheduler_pool)
         self._build_request_handler.start()
@@ -82,10 +80,9 @@ class ClusterMaster(ClusterService):
         :param offset: The starting index of the requested build
         :param limit: The number of builds requested
         """
-        num_builds = len(self._all_builds_by_id)
+        num_builds = BuildStore.size()
         start, end = get_paginated_indices(offset, limit, num_builds)
-        requested_builds = islice(self._all_builds_by_id, start, end)
-        return [self._all_builds_by_id[key] for key in requested_builds]
+        return BuildStore.get_range(start, end)
 
     def active_builds(self):
         """
@@ -257,7 +254,7 @@ class ClusterMaster(ClusterService):
 
         if build_request.is_valid():
             build = Build(build_request)
-            self._all_builds_by_id[build.build_id()] = build
+            BuildStore.add(build)
             build.generate_project_type()  # WIP(joey): This should be internal to the Build object.
             self._build_request_handler.handle_build_request(build)
             response = {'build_id': build.build_id()}
@@ -280,7 +277,7 @@ class ClusterMaster(ClusterService):
         :return: The success/failure and the response we want to send to the requestor
         :rtype: tuple [bool, dict [str, str]]
         """
-        build = self._all_builds_by_id.get(int(build_id))
+        build = BuildStore.get(int(build_id))
         if build is None:
             raise ItemNotFoundError('Invalid build id.')
 
@@ -299,7 +296,7 @@ class ClusterMaster(ClusterService):
         :rtype: str
         """
         self._logger.info('Results received from {} for subjob. (Build {}, Subjob {})', slave_url, build_id, subjob_id)
-        build = self._all_builds_by_id[int(build_id)]
+        build = BuildStore.get(int(build_id))
         slave = self._all_slaves_by_url[slave_url]
         try:
             build.complete_subjob(subjob_id, payload)
@@ -315,7 +312,7 @@ class ClusterMaster(ClusterService):
         :type build_id: int
         :rtype: Build
         """
-        build = self._all_builds_by_id.get(build_id)
+        build = BuildStore.get(build_id)
         if build is None:
             raise ItemNotFoundError('Invalid build id: {}.'.format(build_id))
 
@@ -329,7 +326,7 @@ class ClusterMaster(ClusterService):
         :param is_tar_request: If true, download the tar.gz archive instead of a zip.
         :return: The path to the archived results file
         """
-        build = self._all_builds_by_id.get(build_id)  # type: Build
+        build = BuildStore.get(build_id)  # type: Build
         if build is None:
             raise ItemNotFoundError('Invalid build id.')
 

--- a/test/unit/master/test_cluster_master.py
+++ b/test/unit/master/test_cluster_master.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, Mock
 from app.master.atom import Atom
 from app.master.build import Build
 from app.master.build_request import BuildRequest
+from app.master.build_store import BuildStore
 from app.master.cluster_master import ClusterMaster
 from app.master.subjob import Subjob
 from app.slave.cluster_slave import SlaveState
@@ -115,7 +116,7 @@ class TestClusterMaster(BaseUnitTestCase):
         master = ClusterMaster()
         master.connect_slave('running-slave.turtles.gov', 10)
         build_mock = MagicMock(spec_set=Build)
-        master._all_builds_by_id[1] = build_mock
+        BuildStore._all_builds_by_id[1] = build_mock
         existing_slave = master.get_slave(slave_id=None, slave_url='running-slave.turtles.gov')
         existing_slave.current_build_id = 1
 
@@ -128,7 +129,7 @@ class TestClusterMaster(BaseUnitTestCase):
         update_params = {'key': 'value'}
         master = ClusterMaster()
         build = Mock()
-        master._all_builds_by_id[build_id] = build
+        BuildStore._all_builds_by_id[build_id] = build
         build.validate_update_params = Mock(return_value=(True, update_params))
         build.update_state = Mock()
 
@@ -144,7 +145,7 @@ class TestClusterMaster(BaseUnitTestCase):
         update_params = {'key': 'value'}
         master = ClusterMaster()
         build = Mock()
-        master._all_builds_by_id[build_id] = build
+        BuildStore._all_builds_by_id[build_id] = build
         build.validate_update_params = Mock(return_value=(True, update_params))
         build.update_state = Mock()
 
@@ -221,7 +222,7 @@ class TestClusterMaster(BaseUnitTestCase):
         self.patch_object(build, '_mark_subjob_complete')
 
         master = ClusterMaster()
-        master._all_builds_by_id[build_id] = build
+        BuildStore._all_builds_by_id[build_id] = build
         master._all_slaves_by_url[slave_url] = Mock()
         mock_scheduler = self.mock_scheduler_pool.get(build)
 
@@ -239,7 +240,7 @@ class TestClusterMaster(BaseUnitTestCase):
         mock_build.complete_subjob.side_effect = [RuntimeError('Write failed')]
 
         master = ClusterMaster()
-        master._all_builds_by_id[mock_build.build_id()] = mock_build
+        BuildStore._all_builds_by_id[mock_build.build_id()] = mock_build
         master._all_slaves_by_url[slave_url] = Mock()
         mock_scheduler = self.mock_scheduler_pool.get(mock_build)
 
@@ -256,7 +257,7 @@ class TestClusterMaster(BaseUnitTestCase):
     @given(integers(), dictionaries(text(), text()))
     def test_handle_request_to_update_build_does_not_raise_exception(self, build_id, update_params):
         master = ClusterMaster()
-        master._all_builds_by_id = {build_id: Build({})}
+        BuildStore._all_builds_by_id = {build_id: Build({})}
         master.handle_request_to_update_build(build_id, update_params)
 
     @genty_dataset(
@@ -310,7 +311,7 @@ class TestClusterMaster(BaseUnitTestCase):
         for build_id in range(1, self._NUM_BUILDS + 1):
             build_mock = Mock(spec=Build)
             build_mock.build_id = build_id
-            master._all_builds_by_id[build_id] = build_mock
+            BuildStore._all_builds_by_id[build_id] = build_mock
 
         requested_builds = master.get_builds(offset, limit)
 


### PR DESCRIPTION
Simply move all of the builds from the master service and into a BuildStore class. 

Note that all the builds are still being _created_ by the master, just stored in the BuildStore. 

```python
# build_store.py

@classmethod
def add(cls, build: Build):
    """
    Add new build to collection
    :param build: The build to add to the store
    """
    cls._all_builds_by_id[build.build_id()] = build
```

We'll probably change this later when we add a database/caching layer here, since the build `id`s will be autogenerated. 

Closes #398 