### PR TITLE
Handle build cancellation before atomization and for queued builds

### DIFF
--- a/app/master/build_request_handler.py
+++ b/app/master/build_request_handler.py
@@ -87,7 +87,7 @@ class BuildRequestHandler(object):
                                    log_msg='Build preparation loop is handling request for build {build_id}.')
             try:
                 build.prepare(self._subjob_calculator)
-                if not build.has_error:
+                if not build.is_stopped():
                     analytics.record_event(analytics.BUILD_PREPARE_FINISH, build_id=build.build_id(), is_success=True,
                                            log_msg='Build {build_id} successfully prepared.')
                     # If the atomizer found no work to do, perform build cleanup and skip the slave allocation.

--- a/app/master/build_request_handler.py
+++ b/app/master/build_request_handler.py
@@ -100,6 +100,7 @@ class BuildRequestHandler(object):
                         self._scheduler_pool.add_build_waiting_for_slaves(build)
 
             except Exception as ex:  # pylint: disable=broad-except
-                build.mark_failed(str(ex))  # WIP(joey): Build should do this internally.
-                self._logger.exception('Could not handle build request for build {}.'.format(build.build_id()))
+                if not build.is_canceled:
+                    build.mark_failed(str(ex))  # WIP(joey): Build should do this internally.
+                    self._logger.exception('Could not handle build request for build {}.'.format(build.build_id()))
                 analytics.record_event(analytics.BUILD_PREPARE_FINISH, build_id=build.build_id(), is_success=False)

--- a/app/master/build_request_handler.py
+++ b/app/master/build_request_handler.py
@@ -1,7 +1,6 @@
 from queue import Queue
 from threading import Lock
 
-from app.master.subjob_calculator import SubjobCalculator
 from app.util import analytics
 from app.util.log import get_logger
 from app.util.safe_thread import SafeThread
@@ -35,7 +34,6 @@ class BuildRequestHandler(object):
         self._request_queue_worker_thread = SafeThread(
             target=self._build_preparation_loop, name='RequestHandlerLoop', daemon=True)
         self._project_preparation_locks = {}
-        self._subjob_calculator = SubjobCalculator()
 
     def start(self):
         """
@@ -86,8 +84,8 @@ class BuildRequestHandler(object):
             analytics.record_event(analytics.BUILD_PREPARE_START, build_id=build.build_id(),
                                    log_msg='Build preparation loop is handling request for build {build_id}.')
             try:
-                build.prepare(self._subjob_calculator)
-                if not build.is_stopped():
+                build.prepare()
+                if not build.is_stopped:
                     analytics.record_event(analytics.BUILD_PREPARE_FINISH, build_id=build.build_id(), is_success=True,
                                            log_msg='Build {build_id} successfully prepared.')
                     # If the atomizer found no work to do, perform build cleanup and skip the slave allocation.

--- a/app/master/subjob_calculator.py
+++ b/app/master/subjob_calculator.py
@@ -8,76 +8,72 @@ from app.master.time_based_atom_grouper import TimeBasedAtomGrouper
 from app.util import log
 
 
-class SubjobCalculator(object):
+def compute_subjobs_for_build(build_id, job_config, project_type):
     """
     Calculate subjobs for a build.
+    :type build_id: int
+    :type job_config: JobConfig
+    :param project_type: the project_type that the build is running in
+    :type project_type: project_type.project_type.ProjectType
+    :rtype: list[Subjob]
     """
-    def __init__(self):
-        self._logger = log.get_logger(__name__)
+    # Users can override the list of atoms to be run in this build. If the atoms_override
+    # was specified, we can skip the atomization step and use those overridden atoms instead.
+    if project_type.atoms_override is not None:
+        atoms_string_list = project_type.atoms_override
+        atoms_list = [Atom(atom_string_value) for atom_string_value in atoms_string_list]
+    else:
+        atoms_list = job_config.atomizer.atomize_in_project(project_type)
 
-    def compute_subjobs_for_build(self, build_id, job_config, project_type):
-        """
-        :type build_id: int
-        :type job_config: JobConfig
-        :param project_type: the project_type that the build is running in
-        :type project_type: project_type.project_type.ProjectType
-        :rtype: list[Subjob]
-        """
-        # Users can override the list of atoms to be run in this build. If the atoms_override
-        # was specified, we can skip the atomization step and use those overridden atoms instead.
-        if project_type.atoms_override is not None:
-            atoms_string_list = project_type.atoms_override
-            atoms_list = [Atom(atom_string_value) for atom_string_value in atoms_string_list]
-        else:
-            atoms_list = job_config.atomizer.atomize_in_project(project_type)
+    # Group the atoms together using some grouping strategy
+    timing_file_path = project_type.timing_file_path(job_config.name)
+    grouped_atoms = _grouped_atoms(
+        atoms_list,
+        job_config.max_executors,
+        timing_file_path,
+        project_type.project_directory
+    )
 
-        # Group the atoms together using some grouping strategy
-        timing_file_path = project_type.timing_file_path(job_config.name)
-        grouped_atoms = self._grouped_atoms(
-            atoms_list,
-            job_config.max_executors,
-            timing_file_path,
-            project_type.project_directory
-        )
+    # Generate subjobs for each group of atoms
+    subjobs = []
+    for subjob_id, subjob_atoms in enumerate(grouped_atoms):
+        # The atom id isn't calculated until the atom has been grouped into a subjob.
+        for atom_id, atom in enumerate(subjob_atoms):
+            atom.id = atom_id
+        subjobs.append(Subjob(build_id, subjob_id, project_type, job_config, subjob_atoms))
+    return subjobs
 
-        # Generate subjobs for each group of atoms
-        subjobs = []
-        for subjob_id, subjob_atoms in enumerate(grouped_atoms):
-            # The atom id isn't calculated until the atom has been grouped into a subjob.
-            for atom_id, atom in enumerate(subjob_atoms):
-                atom.id = atom_id
-            subjobs.append(Subjob(build_id, subjob_id, project_type, job_config, subjob_atoms))
-        return subjobs
 
-    def _grouped_atoms(self, atoms, max_executors, timing_file_path, project_directory):
-        """
-        Return atoms that are grouped for optimal CI performance.
+def _grouped_atoms(atoms, max_executors, timing_file_path, project_directory):
+    """
+    Return atoms that are grouped for optimal CI performance.
 
-        If a timing file exists, then use the TimeBasedAtomGrouper.
-        If not, use the default AtomGrouper (groups each atom into its own subjob).
+    If a timing file exists, then use the TimeBasedAtomGrouper.
+    If not, use the default AtomGrouper (groups each atom into its own subjob).
 
-        :param atoms: all of the atoms to be run this time
-        :type atoms: list[app.master.atom.Atom]
-        :param max_executors: the maximum number of executors for this build
-        :type max_executors: int
-        :param timing_file_path: path to where the timing data file would be stored (if it exists) for this job
-        :type timing_file_path: str
-        :type project_directory: str
-        :return: the grouped atoms (in the form of list of lists of strings)
-        :rtype: list[list[app.master.atom.Atom]]
-        """
-        atom_time_map = None
+    :param atoms: all of the atoms to be run this time
+    :type atoms: list[app.master.atom.Atom]
+    :param max_executors: the maximum number of executors for this build
+    :type max_executors: int
+    :param timing_file_path: path to where the timing data file would be stored (if it exists) for this job
+    :type timing_file_path: str
+    :type project_directory: str
+    :return: the grouped atoms (in the form of list of lists of strings)
+    :rtype: list[list[app.master.atom.Atom]]
+    """
+    atom_time_map = None
 
-        if os.path.isfile(timing_file_path):
-            with open(timing_file_path, 'r') as json_file:
-                try:
-                    atom_time_map = json.load(json_file)
-                except ValueError:
-                    self._logger.warning('Failed to load timing data from file that exists {}', timing_file_path)
+    if os.path.isfile(timing_file_path):
+        with open(timing_file_path, 'r') as json_file:
+            try:
+                atom_time_map = json.load(json_file)
+            except ValueError:
+                logger = log.get_logger(__name__)
+                logger.warning('Failed to load timing data from file that exists {}', timing_file_path)
 
-        if atom_time_map is not None and len(atom_time_map) > 0:
-            atom_grouper = TimeBasedAtomGrouper(atoms, max_executors, atom_time_map, project_directory)
-        else:
-            atom_grouper = AtomGrouper(atoms, max_executors)
+    if atom_time_map is not None and len(atom_time_map) > 0:
+        atom_grouper = TimeBasedAtomGrouper(atoms, max_executors, atom_time_map, project_directory)
+    else:
+        atom_grouper = AtomGrouper(atoms, max_executors)
 
-        return atom_grouper.groupings()
+    return atom_grouper.groupings()

--- a/test/unit/master/test_build_request_handler.py
+++ b/test/unit/master/test_build_request_handler.py
@@ -1,5 +1,7 @@
 from genty import genty, genty_dataset
 
+from app.master.atomizer import AtomizerError
+from app.master.build_fsm import BuildState
 from app.master.build_request_handler import BuildRequestHandler
 from test.framework.base_unit_test_case import BaseUnitTestCase
 
@@ -15,7 +17,7 @@ class TestBuildRequestHandler(BaseUnitTestCase):
         build_scheduler_mock = self.patch('app.master.build_scheduler.BuildScheduler').return_value
         build_request_handler = BuildRequestHandler(build_scheduler_mock)
         build_mock = self.patch('app.master.build.Build').return_value
-        build_mock.has_error = False
+        build_mock.is_stopped = False
         build_mock.get_subjobs.return_value = subjobs
 
         build_request_handler._prepare_build_async(build_mock, mock_project_lock)
@@ -24,3 +26,33 @@ class TestBuildRequestHandler(BaseUnitTestCase):
             build_mock.finish.assert_called_once_with()
         else:
             self.assertFalse(build_mock.finish.called)
+
+    def test_prepare_build_async_does_not_call_finish_for_canceled_or_error_build(self):
+        subjobs = []
+        mock_project_lock = self.patch('threading.Lock').return_value
+        build_scheduler_mock = self.patch('app.master.build_scheduler.BuildScheduler').return_value
+        build_request_handler = BuildRequestHandler(build_scheduler_mock)
+        build_mock = self.patch('app.master.build.Build').return_value
+        build_mock.is_stopped = True # this means the BuildState is CANCELED or ERROR
+        build_mock.get_subjobs.return_value = subjobs
+
+        build_request_handler._prepare_build_async(build_mock, mock_project_lock)
+
+        self.assertFalse(build_mock.finish.called, 'Build finish should not be called for CANCELED build')
+
+    @genty_dataset(
+        no_subjobs=([],),
+        one_subjob=(['some subjob'],),
+    )
+    def test_prepare_build_async_does_not_call_mark_failed_for_canceled_build(self, subjobs):
+        mock_project_lock = self.patch('threading.Lock').return_value
+        build_scheduler_mock = self.patch('app.master.build_scheduler.BuildScheduler').return_value
+        build_request_handler = BuildRequestHandler(build_scheduler_mock)
+        build_mock = self.patch('app.master.build.Build').return_value
+        build_mock.get_subjobs.return_value = subjobs
+        build_mock.is_canceled = True
+        build_mock.prepare.side_effect = AtomizerError
+
+        build_request_handler._prepare_build_async(build_mock, mock_project_lock)
+
+        self.assertFalse(build_mock.mark_failed.called, 'Build mark_failed should not be called for CANCELED build')

--- a/test/unit/master/test_cluster_master.py
+++ b/test/unit/master/test_cluster_master.py
@@ -217,7 +217,10 @@ class TestClusterMaster(BaseUnitTestCase):
         build_id = 1
         slave_url = "url"
         build = Build(BuildRequest({}))
+        self.patch('app.master.build.util')
+        build.generate_project_type()
         build.cancel()
+
         self.patch_object(build, '_handle_subjob_payload')
         self.patch_object(build, '_mark_subjob_complete')
 

--- a/test/unit/master/test_subjob_calculator.py
+++ b/test/unit/master/test_subjob_calculator.py
@@ -5,7 +5,7 @@ from genty import genty, genty_dataset
 from app.master.atom import Atom
 from app.master.atomizer import Atomizer
 from app.master.job_config import JobConfig
-from app.master.subjob_calculator import SubjobCalculator
+from app.master.subjob_calculator import compute_subjobs_for_build
 from app.project_type.project_type import ProjectType
 from test.framework.base_unit_test_case import BaseUnitTestCase
 
@@ -35,8 +35,6 @@ class TestSubjobCalculator(BaseUnitTestCase):
         mock_job_config.max_executors = 1
         mock_job_config.atomizer = mock_atomizer
 
-        subjob_calculator = SubjobCalculator()
-        subjob_calculator.compute_subjobs_for_build(build_id=1, job_config=mock_job_config,
-                                                    project_type=mock_project)
+        compute_subjobs_for_build(build_id=1, job_config=mock_job_config, project_type=mock_project)
 
         self.assertEquals(mock_atomizer.atomize_in_project.called, atomizer_called)


### PR DESCRIPTION
This PR handles the build cancellation before atomization and for queued builds.
It basically moves the build atomization and subjob creation code into preparing callback function to avoid explicit checks for canceled build.
Secondly, on build cancel it sets kill_event for all subprocesses for the build.

This PR also makes updates such as 
- post-build tasks will not be executed for canceled build and
- canceled build will not be marked as failed
- for canceled build AtomizerError exception will be attached with more information to make logs readable.
