### PR TITLE
Stop raising prometheus error metric on setup build failure

### DIFF
--- a/app/common/metrics.py
+++ b/app/common/metrics.py
@@ -30,7 +30,6 @@ class ErrorType(str, Enum):
     AtomizerFailure = 'AtomizerFailure'
     NetworkRequestFailure = 'NetworkRequestFailure'
     PostBuildFailure = 'PostBuildFailure'
-    SetupBuildFailure = 'SetupBuildFailure'
     SubjobStartFailure = 'SubjobStartFailure'
     SubjobWriteFailure = 'SubjobWriteFailure'
     ZipFileCreationFailure = 'ZipFileCreationFailure'

--- a/app/master/cluster_master.py
+++ b/app/master/cluster_master.py
@@ -3,7 +3,7 @@ import os
 from typing import List
 
 from app.common.cluster_service import ClusterService
-from app.common.metrics import ErrorType, SlavesCollector, internal_errors
+from app.common.metrics import SlavesCollector
 from app.master.build import Build, MAX_SETUP_FAILURES
 from app.master.build_request import BuildRequest
 from app.master.build_request_handler import BuildRequestHandler
@@ -232,7 +232,6 @@ class ClusterMaster(ClusterService):
 
         :type slave: Slave
         """
-        internal_errors.labels(ErrorType.SetupBuildFailure).inc()  # pylint: disable=no-member
         build = self.get_build(slave.current_build_id)
         build.setup_failures += 1
         if build.setup_failures >= MAX_SETUP_FAILURES:


### PR DESCRIPTION
We used to increment a prometheus error counter whenever build setup
failed. We did this because a failure in build setup used to kill the
slave process. We fixed that in #377. Incrementing the prometheus
counter is now unnecessary noise.