### PR TITLE
Fix AppVeyor badge in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Project Status](http://opensource.box.com/badges/active.svg)](http://opensource.box.com/badges)
 [![Build Status](https://travis-ci.org/box/ClusterRunner.svg?branch=master)](https://travis-ci.org/box/ClusterRunner)
-[![Build status](https://ci.appveyor.com/api/projects/status/gwei54m8anlbxwhn?svg=true)](https://ci.appveyor.com/project/josephharrington/clusterrunner)
+[![Build status](https://ci.appveyor.com/api/projects/status/gwei54m8anlbxwhn/branch/master?svg=true)](https://ci.appveyor.com/project/josephharrington/clusterrunner)
 [![Coverage Status](https://coveralls.io/repos/box/ClusterRunner/badge.svg?branch=master)](https://coveralls.io/r/box/ClusterRunner?branch=master)
 
 # ClusterRunner


### PR DESCRIPTION
Previously this was just pointing to the most recent build which could have been for a PR with errors. This updates the badge to reference the master branch.