### PR TITLE
Support 'None' values in configfile

### DIFF
--- a/app/util/conf/base_config_loader.py
+++ b/app/util/conf/base_config_loader.py
@@ -189,7 +189,7 @@ class BaseConfigLoader(object):
         for key in clusterrunner_config:
             if key not in whitelisted_file_keys:
                 raise InvalidConfigError('The config file contains an invalid key: {}'.format(key))
-            value = clusterrunner_config[key]
+            value = None if clusterrunner_config[key] == 'None' else clusterrunner_config[key]
 
             self._cast_and_set(key, value, config)
 
@@ -217,9 +217,9 @@ class BaseConfigLoader(object):
                 value = [value]
             config.set(key, value)
 
-        else:  # Could be str or NoneType, we assume it should be a str
+        else:  # Could be str or NoneType
             # Hacky: If the value starts with ~, we assume it's a path that needs to be expanded
-            if value.startswith('~'):
+            if value is not None and value.startswith('~'):
                 value = expanduser(value)
             config.set(key, value)
 

--- a/test/unit/util/conf/test_base_config_loader.py
+++ b/test/unit/util/conf/test_base_config_loader.py
@@ -7,7 +7,7 @@ from test.framework.base_unit_test_case import BaseUnitTestCase
 
 class _FakeConfigLoader(BaseConfigLoader):
     def _get_config_file_whitelisted_keys(self):
-        return ['some_bool', 'some_int', 'some_list', 'some_str']
+        return ['some_bool', 'some_int', 'some_list', 'some_str', 'some_none']
 
     def configure_defaults(self, conf):
         super().configure_defaults(conf)
@@ -15,6 +15,7 @@ class _FakeConfigLoader(BaseConfigLoader):
         conf.set('some_int', 1776)
         conf.set('some_list', ['red', 'white', 'blue'])
         conf.set('some_str', 'America!')
+        conf.set('some_none', 'not None')
         conf.set('some_nonwhitelisted_key', 1492)
 
 
@@ -26,6 +27,7 @@ class TestBaseConfigLoader(BaseUnitTestCase):
         int_type=('some_int', '1999', 1999),
         list_type=('some_list', ['a', 'b', 'c'], ['a', 'b', 'c']),
         str_type=('some_str', 'OneTwoThree', 'OneTwoThree'),
+        none_type=('some_none', 'None', None),
     )
     def test_all_datatypes_can_be_overridden_by_value_in_file(self, key, parsed_val, expected_stored_conf_val):
         mock_config_file = self.patch('app.util.conf.base_config_loader.ConfigFile').return_value


### PR DESCRIPTION
If the value for any configuration is set to the string 'None', the
config loader will set it to noneType