### PR TITLE
Kill slave process on non 200 heartbeat response

### DIFF
--- a/app/slave/cluster_slave.py
+++ b/app/slave/cluster_slave.py
@@ -74,24 +74,27 @@ class ClusterSlave(ClusterService):
 
     def _run_heartbeat(self):
         try:
-            self._send_heartbeat_to_master()
-            self._heartbeat_failure_count = 0
+            response = self._send_heartbeat_to_master()
+
+            # A non HTTP 200 response indicates that the master is up, but does not recognize the slave.
+            if not response.ok:
+                self._logger.error('Master did not respond with HTTP 200')
+                self.kill()
+            else:
+                self._heartbeat_failure_count = 0
         except (requests.ConnectionError, requests.Timeout):
             self._heartbeat_failure_count += 1
             if self._heartbeat_failure_count >= self._heartbeat_failure_threshold:
-                self._logger.error('Master is not responding to heartbeats')
-
-                # TODO: Right now the slave simply dies when it does not hear back from master. The next step would
-                # be to try to reconnect to master at this point. In future the heartbeat and connect_to_master
-                # methods can combined into one. This combined method will behave differently based on current state.
+                self._logger.error('Master has not responded to last {} heartbeats.'.format(
+                    self._heartbeat_failure_threshold))
                 self.kill()
 
         self._hb_scheduler.enter(self._heartbeat_interval, 0, self._run_heartbeat)
 
     def _send_heartbeat_to_master(self):
         heartbeat_url = self._master_api.url('slave', self._slave_id, 'heartbeat')
-        self._network.post_with_digest(heartbeat_url, request_params={'slave': {'heartbeat': True}},
-                                       secret=Secret.get())
+        return self._network.post_with_digest(heartbeat_url, request_params={'slave': {'heartbeat': True}},
+                                              secret=Secret.get())
 
     def api_representation(self):
         """

--- a/test/unit/slave/test_cluster_slave.py
+++ b/test/unit/slave/test_cluster_slave.py
@@ -280,6 +280,7 @@ class TestClusterSlave(BaseUnitTestCase):
 
         mock_response = MagicMock(spec=requests.models.Response, create=True)
         mock_response.ok = False
+        mock_response.status_code = http.client.NOT_FOUND
         self.mock_network.post_with_digest.return_value = mock_response
 
         slave._run_heartbeat()

--- a/test/unit/slave/test_cluster_slave.py
+++ b/test/unit/slave/test_cluster_slave.py
@@ -150,6 +150,7 @@ class TestClusterSlave(BaseUnitTestCase):
         def _get_success_mock_response():
             mock_response = MagicMock(spec=requests.models.Response, create=True)
             mock_response.status_code = http.client.OK
+            mock_response.ok = True
             return mock_response
 
         def fake_network_post(url, *args, **kwargs):
@@ -256,6 +257,7 @@ class TestClusterSlave(BaseUnitTestCase):
 
         slave = self._create_cluster_slave()
         slave.connect_to_master(self._FAKE_MASTER_URL)
+
         if not is_master_responsive:
             self.mock_network.post_with_digest.side_effect = requests.ConnectionError
 
@@ -271,6 +273,21 @@ class TestClusterSlave(BaseUnitTestCase):
             else:
                 self.assertEqual(self._mock_sys.exit.call_count, 0,
                                  'slave keeps running when heartbeat failure threshold is not reached')
+
+    def test_slave_dies_on_http_404_from_master(self):
+        slave = self._create_cluster_slave()
+        slave.connect_to_master(self._FAKE_MASTER_URL)
+
+        mock_response = MagicMock(spec=requests.models.Response, create=True)
+        mock_response.ok = False
+        self.mock_network.post_with_digest.return_value = mock_response
+
+        slave._run_heartbeat()
+
+        self.mock_network.post_with_digest.assert_called_once_with(
+                        ANY,request_params={'slave': {'heartbeat': True}}, secret=ANY)
+        self.assertEqual(self._mock_sys.exit.call_count, 1,
+                         'slave dies when it receives HTTP 404 from master')
 
     def _create_cluster_slave(self, **kwargs):
         """


### PR DESCRIPTION
If heartbeat response is not HTTP 200, it means that the master is up,
but does not recognize the slave. In such cases the slave should
immediately try to reconnect to master. This event should also be
considered as heartbeat failure and increment the heartbeat failure
count. If the slave gets more failures than the threshold, the process
dies