### PR TITLE
Fix bug with slave reconnection

### DIFF
--- a/app/master/cluster_master.py
+++ b/app/master/cluster_master.py
@@ -160,6 +160,9 @@ class ClusterMaster(ClusterService):
                     self._logger.info('Failed to find build {} that was running on {}', old_slave.current_build_id,
                                       old_slave)
 
+            # Remove old slave from registry
+            self._slave_registry.remove_slave(slave=old_slave)
+
         slave = Slave(slave_url, num_executors, slave_session_id)
         self._slave_registry.add_slave(slave)
         self._slave_allocator.add_idle_slave(slave)

--- a/test/unit/master/test_cluster_master.py
+++ b/test/unit/master/test_cluster_master.py
@@ -69,6 +69,19 @@ class TestClusterMaster(BaseUnitTestCase):
         self.assertIsNotNone(slave_registry.get_slave(slave_id=None, slave_url='never-before-seen.turtles.gov'),
                              'Registered slave does not have the expected url.')
 
+    def test_connect_slave_with_existing_dead_slave_removes_old_slave_entry_from_registry(self):
+        master = ClusterMaster()
+        slave_registry = SlaveRegistry.singleton()
+
+        master.connect_slave('existing-slave.turtles.gov', 10)
+        old_existing_slave = slave_registry.get_slave(slave_id=None, slave_url='existing-slave.turtles.gov')
+        old_existing_slave_id = old_existing_slave.id
+
+        connect_response = master.connect_slave('existing-slave.turtles.gov', 10)
+
+        with self.assertRaises(ItemNotFoundError):
+            slave_registry.get_slave(slave_id=old_existing_slave_id)
+
     def test_connect_slave_with_existing_dead_slave_creates_new_alive_instance(self):
         master = ClusterMaster()
         slave_registry = SlaveRegistry.singleton()


### PR DESCRIPTION
When slave is reconnected the old-slave entry should be removed
from slave registry, before adding new entry for the same slave.