### PR TITLE
Update last heartbeat time only if slave is alive

### DIFF
--- a/app/master/cluster_master.py
+++ b/app/master/cluster_master.py
@@ -192,8 +192,16 @@ class ClusterMaster(ClusterService):
         do_transition = slave_transition_functions.get(new_slave_state)
         do_transition(slave)
 
-    def update_slave_last_heartbeat_time(self, slave):
-        slave.update_last_heartbeat_time()
+    def update_slave_last_heartbeat_time(self, slave) -> bool:
+        """
+        Updates last heartbeat time for the slave if it is alive.
+        :type slave: Slave
+        :return: True when the slave is alive.
+        """
+        if slave.is_alive():
+            slave.update_last_heartbeat_time()
+            return True
+        return False
 
     def set_shutdown_mode_on_slaves(self, slave_ids):
         """

--- a/app/slave/cluster_slave.py
+++ b/app/slave/cluster_slave.py
@@ -81,6 +81,11 @@ class ClusterSlave(ClusterService):
                 self._logger.error('Received HTTP {} from master.'.format(response.status_code))
                 self._logger.error('The slave process is shutting down.')
                 self.kill()
+            # is_alive = False indicates slave is marked offline in master
+            elif not response.json().get('is_alive'):
+                self._logger.error('The slave is marked dead by master.')
+                self._logger.error('The slave process is shutting down.')
+                self.kill()
             else:
                 self._heartbeat_failure_count = 0
         except (requests.ConnectionError, requests.Timeout):

--- a/test/unit/master/test_cluster_master.py
+++ b/test/unit/master/test_cluster_master.py
@@ -209,13 +209,18 @@ class TestClusterMaster(BaseUnitTestCase):
         with self.assertRaises(BadRequestError):
             master.handle_slave_state_update(slave, 'NONEXISTENT_STATE')
 
-    def test_update_slave_last_heartbeat_time_calls_update_last_heartbeat_time_on_slave(self):
+    @genty_dataset (
+        slave_alive=(True,1,),
+        slave_dead=(False,0,),
+    )
+    def test_update_slave_last_heartbeat_time_calls_correspondig_slave_method(self, slave_alive, method_call_count):
         master = ClusterMaster()
 
         mock_slave = self.patch('app.master.cluster_master.Slave').return_value
+        mock_slave.is_alive.return_value = slave_alive
         master.update_slave_last_heartbeat_time(mock_slave)
 
-        self.assertEqual(mock_slave.update_last_heartbeat_time.call_count, 1,
+        self.assertEqual(mock_slave.update_last_heartbeat_time.call_count, method_call_count,
                          'last heartbeat time is updated for the target slave')
 
     @genty_dataset (


### PR DESCRIPTION
If the slave has been marked alive, but still sends heartbeat, the
master should not update the last heartbeat time. At the same time,
master should respond to the slave indicating that it has been marked
dead.