### PR TITLE
Move SlaveRegistry reset to baseUnitTestCase

### DIFF
--- a/test/framework/base_unit_test_case.py
+++ b/test/framework/base_unit_test_case.py
@@ -6,7 +6,7 @@ from unittest import TestCase
 from unittest.mock import MagicMock, NonCallableMock, patch
 
 from app.master.build import Build
-from app.master.slave import Slave
+from app.master.slave import Slave, SlaveRegistry
 from app.util import analytics, log
 from app.util.conf.configuration import Configuration
 from app.util.conf.master_config_loader import MasterConfigLoader
@@ -46,6 +46,7 @@ class BaseUnitTestCase(TestCase):
         # Reset singletons so that they get recreated for every test that uses them.
         Configuration.reset_singleton()
         UnhandledExceptionHandler.reset_singleton()
+        SlaveRegistry.reset_singleton()
 
         # Explicitly initialize UnhandledExceptionHandler singleton here (on the main thread) since it sets up signal
         # handlers that must execute on the main thread.

--- a/test/functional/test_cluster_basic.py
+++ b/test/functional/test_cluster_basic.py
@@ -73,7 +73,6 @@ class TestClusterBasic(BaseFunctionalTestCase):
             build_id=build_id, expected_build_artifact_contents=expected_artifact_contents)
 
     def test_slave_reconnection_does_not_take_down_master(self):
-        SlaveRegistry.reset_singleton()
         test_config = JOB_WITH_SETUP_AND_TEARDOWN
         job_config = yaml.safe_load(test_config.config[os.name])['JobWithSetupAndTeardown']
         master = self.cluster.start_master()

--- a/test/unit/master/test_cluster_master.py
+++ b/test/unit/master/test_cluster_master.py
@@ -48,8 +48,6 @@ class TestClusterMaster(BaseUnitTestCase):
         self._thread_pool_executor_cls.return_value.submit.side_effect = \
             self.thread_pool_executor.submit
 
-        SlaveRegistry.reset_singleton()
-
         Configuration['pagination_offset'] = self._PAGINATION_OFFSET
         Configuration['pagination_limit'] = self._PAGINATION_LIMIT
         Configuration['pagination_max_limit'] = self._PAGINATION_MAX_LIMIT

--- a/test/unit/master/test_slave.py
+++ b/test/unit/master/test_slave.py
@@ -258,7 +258,6 @@ class TestSlave(BaseUnitTestCase):
 class TestSlaveRegistry(BaseUnitTestCase):
     def setUp(self):
         super().setUp()
-        SlaveRegistry.reset_singleton()
 
     @genty_dataset(
         slave_id_specified=({'slave_id': 400},),


### PR DESCRIPTION
Moved SlaveRegistry singleton reset to baseUnitTestCase. That's where we reset Configuration and UnhandledExceptionHandler singletons.